### PR TITLE
Increase group size limit to 100

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -1386,7 +1386,7 @@ Schlüsselaustausch-Nachricht für eine ungültige Protokollversion empfangen</s
   <string name="activity_create_closed_group_empty_state_button_title">Session starten</string>
   <string name="activity_create_closed_group_group_name_missing_error">Bitte geben Sie einen Gruppennamen ein.</string>
   <string name="activity_create_closed_group_group_name_too_long_error">Bitte geben Sie einen kürzeren Gruppennamen ein.</string>
-  <string name="activity_create_closed_group_too_many_group_members_error">Eine geschlossene Gruppe kann maximal 20 Mitglieder haben.</string>
+  <string name="activity_create_closed_group_too_many_group_members_error">Eine geschlossene Gruppe kann maximal 100 Mitglieder haben.</string>
   <string name="activity_create_closed_group_invalid_session_id_error">Ein Mitglied Ihrer Gruppe hat eine ungültige Session ID.</string>
 
   <string name="activity_join_public_chat_title">Offener Gruppe beitreten</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -1398,7 +1398,7 @@ Se recibió un mensaje de intercambio de claves para una versión no válida del
   <string name="activity_create_closed_group_empty_state_button_title">Empezar una Session</string>
   <string name="activity_create_closed_group_group_name_missing_error">Por favor, ingresa un nombre de grupo</string>
   <string name="activity_create_closed_group_group_name_too_long_error">Por favor, ingresa un nombre de grupo más corto</string>
-  <string name="activity_create_closed_group_too_many_group_members_error">Un grupo cerrado no puede tener más de 20 miembros</string>
+  <string name="activity_create_closed_group_too_many_group_members_error">Un grupo cerrado no puede tener más de 100 miembros</string>
   <string name="activity_create_closed_group_invalid_session_id_error">Uno de los miembros de tu grupo tiene un ID de Session no válido</string>
 
   <string name="activity_join_public_chat_title">Únete al grupo abierto</string>

--- a/res/values-fa/strings.xml
+++ b/res/values-fa/strings.xml
@@ -1312,7 +1312,7 @@
   <string name="activity_create_closed_group_empty_state_button_title">شروع Session</string>
   <string name="activity_create_closed_group_group_name_missing_error">لطفا یک نام گروه وارد کنید</string>
   <string name="activity_create_closed_group_group_name_too_long_error">لطفا نام گروه کوتاه‌تری وارد کنید</string>
-  <string name="activity_create_closed_group_too_many_group_members_error">یک گروه خصوصی نمی‌تواند بیش از بیست عضو داشته باشد</string>
+  <string name="activity_create_closed_group_too_many_group_members_error">یک گروه خصوصی نمی‌تواند بیش از یکصد عضو داشته باشد</string>
   <string name="activity_create_closed_group_invalid_session_id_error">یکی از اعضای گروه شما دارای شناسه نامعتبر است</string>
 
   <string name="activity_join_public_chat_title">به گروه باز بپیوندید</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -1393,7 +1393,7 @@ Vous avez reçu un message d’échange de clés pour une version de protocole i
   <string name="activity_create_closed_group_empty_state_button_title">Démarrer une session</string>
   <string name="activity_create_closed_group_group_name_missing_error">Veuillez saisir un nom de groupe</string>
   <string name="activity_create_closed_group_group_name_too_long_error">Veuillez saisir un nom de groupe plus court</string>
-  <string name="activity_create_closed_group_too_many_group_members_error">Un groupe privé ne peut pas avoir plus de 20 membres</string>
+  <string name="activity_create_closed_group_too_many_group_members_error">Un groupe privé ne peut pas avoir plus de 100 membres</string>
   <string name="activity_create_closed_group_invalid_session_id_error">Un des membres de votre groupe a un Session ID non valide</string>
 
   <string name="activity_join_public_chat_title">Joindre un groupe public</string>

--- a/res/values-in/strings.xml
+++ b/res/values-in/strings.xml
@@ -1351,7 +1351,7 @@ Diterima pesan pertukaran kunci untuk versi protokol yang tidak valid.
   <string name="activity_create_closed_group_group_name_missing_error">Masukkan nama grup</string>
   <string name="activity_create_closed_group_group_name_too_long_error">Masukkan nama grup yang lebih pendek</string>
   <string name="activity_create_closed_group_not_enough_group_members_error">Pilih setidaknya 2 anggota grup</string>
-  <string name="activity_create_closed_group_too_many_group_members_error">Grup tertutup maksimal berisi 20 anggota</string>
+  <string name="activity_create_closed_group_too_many_group_members_error">Grup tertutup maksimal berisi 100 anggota</string>
   <string name="activity_create_closed_group_invalid_session_id_error">Salah satu anggota di grup memiliki Session ID yang salah</string>
 
   <string name="activity_join_public_chat_title">Gabung ke grup terbuka</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -1394,7 +1394,7 @@ Ricevuto un messaggio di scambio chiavi per una versione di protocollo non valid
   <string name="activity_create_closed_group_empty_state_button_title">Inizia una sessione</string>
   <string name="activity_create_closed_group_group_name_missing_error">Inserisci un nome per il gruppo</string>
   <string name="activity_create_closed_group_group_name_too_long_error">Inserisci un nome gruppo più breve</string>
-  <string name="activity_create_closed_group_too_many_group_members_error">Un gruppo chiuso non può avere più di 20 membri</string>
+  <string name="activity_create_closed_group_too_many_group_members_error">Un gruppo chiuso non può avere più di 100 membri</string>
   <string name="activity_create_closed_group_invalid_session_id_error">Uno dei membri del tuo gruppo ha una Sessione ID non valido</string>
 
   <string name="activity_join_public_chat_title">Unisciti a un gruppo aperto</string>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -1357,7 +1357,7 @@
   <string name="activity_create_closed_group_group_name_missing_error">グループ名を入力してください</string>
   <string name="activity_create_closed_group_group_name_too_long_error">短いグループ名を入力してください</string>
   <string name="activity_create_closed_group_not_enough_group_members_error">グループメンバーを少なくとも 2 人選択してください</string>
-  <string name="activity_create_closed_group_too_many_group_members_error">閉じたグループは 20 人を超えるメンバーを抱えることはできません</string>
+  <string name="activity_create_closed_group_too_many_group_members_error">閉じたグループは 100 人を超えるメンバーを抱えることはできません</string>
   <string name="activity_create_closed_group_invalid_session_id_error">グループのメンバーの 1 人の Session ID が無効です</string>
 
   <string name="activity_join_public_chat_title">オープングループに参加する</string>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -1449,7 +1449,7 @@ Otrzymano wiadomość wymiany klucz dla niepoprawnej wersji protokołu.</string>
   <string name="activity_create_closed_group_empty_state_button_title">Rozpocznij sesję</string>
   <string name="activity_create_closed_group_group_name_missing_error">Wpisz nazwę grupy</string>
   <string name="activity_create_closed_group_group_name_too_long_error">Wprowadź krótszą nazwę grupy</string>
-  <string name="activity_create_closed_group_too_many_group_members_error">Grupa zamknięta nie może mieć więcej niż 20 członków</string>
+  <string name="activity_create_closed_group_too_many_group_members_error">Grupa zamknięta nie może mieć więcej niż 100 członków</string>
   <string name="activity_create_closed_group_invalid_session_id_error">Jeden z członków Twojej grupy ma nieprawidłowy identyfikator Session</string>
 
   <string name="activity_join_public_chat_title">Dołącz do otwartej grupy</string>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -1397,7 +1397,7 @@
   <string name="activity_create_closed_group_empty_state_button_title">Iniciar uma sessão</string>
   <string name="activity_create_closed_group_group_name_missing_error">Digite um nome de grupo</string>
   <string name="activity_create_closed_group_group_name_too_long_error">Digite um nome de grupo mais curto</string>
-  <string name="activity_create_closed_group_too_many_group_members_error">Um grupo fechado não pode ter mais de 20 membros</string>
+  <string name="activity_create_closed_group_too_many_group_members_error">Um grupo fechado não pode ter mais de 100 membros</string>
   <string name="activity_create_closed_group_invalid_session_id_error">Um dos membros do seu grupo tem um ID Session inválido</string>
 
   <string name="activity_join_public_chat_title">Participar em grupo aberto</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -1451,7 +1451,7 @@
   <string name="activity_create_closed_group_empty_state_button_title">Начать Сессию</string>
   <string name="activity_create_closed_group_group_name_missing_error">Пожалуйста, введите название группы</string>
   <string name="activity_create_closed_group_group_name_too_long_error">Пожалуйста, введите более короткое имя группы</string>
-  <string name="activity_create_closed_group_too_many_group_members_error">В закрытой группе не может быть больше 20 участников</string>
+  <string name="activity_create_closed_group_too_many_group_members_error">В закрытой группе не может быть больше 100 участников</string>
   <string name="activity_create_closed_group_invalid_session_id_error">Один из участников вашей группы имеет недопустимый Session ID</string>
 
   <string name="activity_join_public_chat_title">Присоединиться к открытой группе</string>

--- a/res/values-vi/strings.xml
+++ b/res/values-vi/strings.xml
@@ -845,7 +845,7 @@ Các tin nhắn và cuộc gọi riêng tư miễn phí đến người dùng Si
   <string name="activity_create_closed_group_group_name_missing_error">Vui lòng nhập tên nhóm</string>
   <string name="activity_create_closed_group_group_name_too_long_error">Vui lòng nhập một tên nhóm ngắn hơn </string>
   <string name="activity_create_closed_group_not_enough_group_members_error">Vui lòng chọn ít nhất 2 thành viên trong nhóm </string>
-  <string name="activity_create_closed_group_too_many_group_members_error">Một nhóm kín không thể có nhiều hơn 20 thành viên </string>
+  <string name="activity_create_closed_group_too_many_group_members_error">Một nhóm kín không thể có nhiều hơn 100 thành viên</string>
   <string name="activity_create_closed_group_invalid_session_id_error">Một trong các thành viên trong nhóm của bạn có Session ID không hợp lệ </string>
 
   <string name="activity_join_public_chat_title">Tham gia nhóm mở</string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -1364,7 +1364,7 @@
   <string name="activity_create_closed_group_empty_state_button_title">开始对话</string>
   <string name="activity_create_closed_group_group_name_missing_error">请输入群组名称</string>
   <string name="activity_create_closed_group_group_name_too_long_error">请输入较短的群组名称</string>
-  <string name="activity_create_closed_group_too_many_group_members_error">私密群组成员不得超过20个</string>
+  <string name="activity_create_closed_group_too_many_group_members_error">私密群组成员不得超过100个</string>
   <string name="activity_create_closed_group_invalid_session_id_error">您群组中的一位成员的Session ID无效</string>
 
   <string name="activity_join_public_chat_title">加入公开群组</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1748,7 +1748,7 @@
     <string name="activity_create_closed_group_group_name_missing_error">Please enter a group name</string>
     <string name="activity_create_closed_group_group_name_too_long_error">Please enter a shorter group name</string>
     <string name="activity_create_closed_group_not_enough_group_members_error">Please pick at least 1 group member</string>
-    <string name="activity_create_closed_group_too_many_group_members_error">A closed group cannot have more than 20 members</string>
+    <string name="activity_create_closed_group_too_many_group_members_error">A closed group cannot have more than 100 members</string>
     <string name="activity_create_closed_group_invalid_session_id_error">One of the members of your group has an invalid Session ID</string>
 
     <string name="activity_join_public_chat_title">Join Open Group</string>

--- a/src/org/thoughtcrime/securesms/loki/activities/CreateClosedGroupActivity.kt
+++ b/src/org/thoughtcrime/securesms/loki/activities/CreateClosedGroupActivity.kt
@@ -22,7 +22,6 @@ import org.thoughtcrime.securesms.database.Address
 import org.thoughtcrime.securesms.database.DatabaseFactory
 import org.thoughtcrime.securesms.database.ThreadDatabase
 import org.thoughtcrime.securesms.groups.GroupManager
-import org.thoughtcrime.securesms.loki.protocol.ClosedGroupsProtocol
 import org.thoughtcrime.securesms.loki.protocol.ClosedGroupsProtocolV2
 import org.thoughtcrime.securesms.loki.utilities.fadeIn
 import org.thoughtcrime.securesms.loki.utilities.fadeOut
@@ -43,7 +42,7 @@ class CreateClosedGroupActivity : PassphraseRequiredActionBarActivity(), LoaderM
     }
 
     companion object {
-        val closedGroupCreatedResultCode = 100
+        const val closedGroupCreatedResultCode = 100
     }
 
     // region Lifecycle
@@ -98,14 +97,6 @@ class CreateClosedGroupActivity : PassphraseRequiredActionBarActivity(), LoaderM
     }
 
     private fun createClosedGroup() {
-        if (ClosedGroupsProtocol.isSharedSenderKeysEnabled) {
-            createSSKBasedClosedGroup()
-        } else {
-            createLegacyClosedGroup()
-        }
-    }
-
-    private fun createSSKBasedClosedGroup() {
         val name = nameEditText.text.trim()
         if (name.isEmpty()) {
             return Toast.makeText(this, R.string.activity_create_closed_group_group_name_missing_error, Toast.LENGTH_LONG).show()
@@ -117,7 +108,7 @@ class CreateClosedGroupActivity : PassphraseRequiredActionBarActivity(), LoaderM
         if (selectedMembers.count() < 1) {
             return Toast.makeText(this, R.string.activity_create_closed_group_not_enough_group_members_error, Toast.LENGTH_LONG).show()
         }
-        if (selectedMembers.count() >= ClosedGroupsProtocol.groupSizeLimit) { // Minus one because we're going to include self later
+        if (selectedMembers.count() >= ClosedGroupsProtocolV2.groupSizeLimit) { // Minus one because we're going to include self later
             return Toast.makeText(this, R.string.activity_create_closed_group_too_many_group_members_error, Toast.LENGTH_LONG).show()
         }
         val userPublicKey = TextSecurePreferences.getLocalNumber(this)
@@ -133,61 +124,9 @@ class CreateClosedGroupActivity : PassphraseRequiredActionBarActivity(), LoaderM
             }
         }
     }
-
-    private fun createLegacyClosedGroup() {
-        val name = nameEditText.text.trim()
-        if (name.isEmpty()) {
-            return Toast.makeText(this, R.string.activity_create_closed_group_group_name_missing_error, Toast.LENGTH_LONG).show()
-        }
-        if (name.length >= 64) {
-            return Toast.makeText(this, R.string.activity_create_closed_group_group_name_too_long_error, Toast.LENGTH_LONG).show()
-        }
-        val selectedMembers = this.selectContactsAdapter.selectedMembers
-        if (selectedMembers.count() < 1) {
-            return Toast.makeText(this, R.string.activity_create_closed_group_not_enough_group_members_error, Toast.LENGTH_LONG).show()
-        }
-        if (selectedMembers.count() > 10) {
-            return Toast.makeText(this, R.string.activity_create_closed_group_too_many_group_members_error, Toast.LENGTH_LONG).show()
-        }
-        val recipients = selectedMembers.map {
-            Recipient.from(this, Address.fromSerialized(it), false)
-        }.toSet()
-        val masterHexEncodedPublicKey = TextSecurePreferences.getMasterHexEncodedPublicKey(this) ?: TextSecurePreferences.getLocalNumber(this)
-        val admin = Recipient.from(this, Address.fromSerialized(masterHexEncodedPublicKey), false)
-        CreateClosedGroupTask(WeakReference(this), null, name.toString(), recipients, setOf( admin ))
-            .executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR)
-    }
     // endregion
 
-    // region Group Creation Task (Legacy)
-    internal class CreateClosedGroupTask(
-        private val activity: WeakReference<CreateClosedGroupActivity>,
-        private val profilePicture: Bitmap?,
-        private val name: String?,
-        private val members: Set<Recipient>,
-        private val admins: Set<Recipient>
-    ) : AsyncTask<Void, Void, Optional<GroupManager.GroupActionResult>>() {
-
-        override fun doInBackground(vararg params: Void?): Optional<GroupManager.GroupActionResult> {
-            val activity = activity.get() ?: return Optional.absent()
-            return Optional.of(GroupManager.createGroup(activity, members, profilePicture, name, false, admins))
-        }
-
-        override fun onPostExecute(result: Optional<GroupManager.GroupActionResult>) {
-            val activity = activity.get() ?: return super.onPostExecute(result)
-            if (result.isPresent && result.get().threadId > -1) {
-                if (!activity.isFinishing) {
-                    openConversationActivity(activity, result.get().threadId, result.get().groupRecipient)
-                    activity.finish()
-                }
-            } else {
-                super.onPostExecute(result)
-                Toast.makeText(activity.applicationContext, R.string.activity_create_closed_group_invalid_session_id_error, Toast.LENGTH_LONG).show()
-            }
-        }
-    }
 }
-// endregion
 
 // region Convenience
 private fun openConversationActivity(context: Context, threadId: Long, recipient: Recipient) {

--- a/src/org/thoughtcrime/securesms/loki/activities/EditClosedGroupActivity.kt
+++ b/src/org/thoughtcrime/securesms/loki/activities/EditClosedGroupActivity.kt
@@ -243,7 +243,7 @@ class EditClosedGroupActivity : PassphraseRequiredActionBarActivity() {
             return Toast.makeText(this, R.string.activity_edit_closed_group_not_enough_group_members_error, Toast.LENGTH_LONG).show()
         }
 
-        val maxGroupMembers = if (isSSKBasedClosedGroup) ClosedGroupsProtocol.groupSizeLimit else legacyGroupSizeLimit
+        val maxGroupMembers = if (isSSKBasedClosedGroup) ClosedGroupsProtocolV2.groupSizeLimit else legacyGroupSizeLimit
         if (members.size >= maxGroupMembers) {
             // TODO: Update copy for SSK based closed groups
             return Toast.makeText(this, R.string.activity_edit_closed_group_too_many_group_members_error, Toast.LENGTH_LONG).show()

--- a/src/org/thoughtcrime/securesms/loki/protocol/ClosedGroupsProtocol.kt
+++ b/src/org/thoughtcrime/securesms/loki/protocol/ClosedGroupsProtocol.kt
@@ -37,8 +37,6 @@ import java.util.*
 import kotlin.jvm.Throws
 
 object ClosedGroupsProtocol {
-    val isSharedSenderKeysEnabled = true
-    val groupSizeLimit = 20
 
     sealed class Error(val description: String) : Exception() {
         object NoThread : Error("Couldn't find a thread associated with the given group public key")
@@ -46,54 +44,8 @@ object ClosedGroupsProtocol {
         object InvalidUpdate : Error("Invalid group update.")
     }
 
-    public fun createClosedGroup(context: Context, name: String, members: Collection<String>): Promise<String, Exception> {
-        val deferred = deferred<String, Exception>()
-        Thread {
-            // Prepare
-            val userPublicKey = TextSecurePreferences.getLocalNumber(context)
-            // Generate a key pair for the group
-            val groupKeyPair = Curve.generateKeyPair()
-            val groupPublicKey = groupKeyPair.hexEncodedPublicKey // Includes the "05" prefix
-            val membersAsData = members.map { Hex.fromStringCondensed(it) }
-            // Create ratchets for all members
-            val senderKeys: List<ClosedGroupSenderKey> = members.map { publicKey ->
-                val ratchet = SharedSenderKeysImplementation.shared.generateRatchet(groupPublicKey, publicKey)
-                ClosedGroupSenderKey(Hex.fromStringCondensed(ratchet.chainKey), ratchet.keyIndex, Hex.fromStringCondensed(publicKey))
-            }
-            // Create the group
-            val groupID = doubleEncodeGroupID(groupPublicKey)
-            val admins = setOf( userPublicKey )
-            DatabaseFactory.getGroupDatabase(context).create(groupID, name, LinkedList<Address>(members.map { Address.fromSerialized(it) }),
-                null, null, LinkedList<Address>(admins.map { Address.fromSerialized(it) }))
-            DatabaseFactory.getRecipientDatabase(context).setProfileSharing(Recipient.from(context, Address.fromSerialized(groupID), false), true)
-            // Establish sessions if needed
-            establishSessionsWithMembersIfNeeded(context, members)
-            // Send a closed group update message to all members using established channels
-            val adminsAsData = admins.map { Hex.fromStringCondensed(it) }
-            val closedGroupUpdateKind = ClosedGroupUpdateMessageSendJob.Kind.New(Hex.fromStringCondensed(groupPublicKey), name, groupKeyPair.privateKey.serialize(),
-                senderKeys, membersAsData, adminsAsData)
-            for (member in members) {
-                if (member == userPublicKey) { continue }
-                val job = ClosedGroupUpdateMessageSendJob(member, closedGroupUpdateKind)
-                job.setContext(context)
-                job.onRun() // Run the job immediately to make all of this sync
-            }
-            // Add the group to the user's set of public keys to poll for
-            DatabaseFactory.getSSKDatabase(context).setClosedGroupPrivateKey(groupPublicKey, groupKeyPair.hexEncodedPrivateKey)
-            // Notify the user
-            val threadID = DatabaseFactory.getThreadDatabase(context).getOrCreateThreadIdFor(Recipient.from(context, Address.fromSerialized(groupID), false))
-            insertOutgoingInfoMessage(context, groupID, GroupContext.Type.UPDATE, name, members, admins, threadID)
-            // Notify the PN server
-            LokiPushNotificationManager.performOperation(context, ClosedGroupOperation.Subscribe, groupPublicKey, userPublicKey)
-            // Fulfill the promise
-            deferred.resolve(groupID)
-        }.start()
-        // Return
-        return deferred.promise
-    }
-
     @JvmStatic
-    public fun leave(context: Context, groupPublicKey: String) {
+    fun leave(context: Context, groupPublicKey: String) {
         val userPublicKey = TextSecurePreferences.getLocalNumber(context)
         val groupDB = DatabaseFactory.getGroupDatabase(context)
         val groupID = doubleEncodeGroupID(groupPublicKey)
@@ -108,7 +60,7 @@ object ClosedGroupsProtocol {
         return update(context, groupPublicKey, newMembers, name).get()
     }
 
-    public fun update(context: Context, groupPublicKey: String, members: Collection<String>, name: String): Promise<Unit, Exception> {
+    fun update(context: Context, groupPublicKey: String, members: Collection<String>, name: String): Promise<Unit, Exception> {
         val deferred = deferred<Unit, Exception>()
         Thread {
             val userPublicKey = TextSecurePreferences.getLocalNumber(context)
@@ -237,7 +189,7 @@ object ClosedGroupsProtocol {
     }
 
     @JvmStatic
-    public fun requestSenderKey(context: Context, groupPublicKey: String, senderPublicKey: String) {
+    fun requestSenderKey(context: Context, groupPublicKey: String, senderPublicKey: String) {
         Log.d("Loki", "Requesting sender key for group public key: $groupPublicKey, sender public key: $senderPublicKey.")
         // Establish session if needed
         ApplicationContext.getInstance(context).sendSessionRequestIfNeeded(senderPublicKey)
@@ -245,217 +197,6 @@ object ClosedGroupsProtocol {
         val closedGroupUpdateKind = ClosedGroupUpdateMessageSendJob.Kind.SenderKeyRequest(Hex.fromStringCondensed(groupPublicKey))
         val job = ClosedGroupUpdateMessageSendJob(senderPublicKey, closedGroupUpdateKind)
         ApplicationContext.getInstance(context).jobManager.add(job)
-    }
-
-    @JvmStatic
-    public fun handleSharedSenderKeysUpdate(context: Context, closedGroupUpdate: SignalServiceProtos.ClosedGroupUpdate, senderPublicKey: String) {
-        if (!isValid(closedGroupUpdate)) { return; }
-        when (closedGroupUpdate.type) {
-            SignalServiceProtos.ClosedGroupUpdate.Type.NEW -> handleNewClosedGroup(context, closedGroupUpdate, senderPublicKey)
-            SignalServiceProtos.ClosedGroupUpdate.Type.INFO -> handleClosedGroupUpdate(context, closedGroupUpdate, senderPublicKey)
-            SignalServiceProtos.ClosedGroupUpdate.Type.SENDER_KEY_REQUEST -> handleSenderKeyRequest(context, closedGroupUpdate, senderPublicKey)
-            SignalServiceProtos.ClosedGroupUpdate.Type.SENDER_KEY -> handleSenderKey(context, closedGroupUpdate, senderPublicKey)
-            else -> {
-                // Do nothing
-            }
-        }
-    }
-
-    private fun isValid(closedGroupUpdate: SignalServiceProtos.ClosedGroupUpdate): Boolean {
-        if (closedGroupUpdate.groupPublicKey.isEmpty) { return false }
-        when (closedGroupUpdate.type) {
-            SignalServiceProtos.ClosedGroupUpdate.Type.NEW -> {
-                return !closedGroupUpdate.name.isNullOrEmpty() && !(closedGroupUpdate.groupPrivateKey ?: ByteString.copyFrom(ByteArray(0))).isEmpty
-                    && closedGroupUpdate.membersCount > 0 && closedGroupUpdate.adminsCount > 0 // senderKeys may be empty
-            }
-            SignalServiceProtos.ClosedGroupUpdate.Type.INFO -> {
-                return !closedGroupUpdate.name.isNullOrEmpty() && closedGroupUpdate.membersCount > 0 && closedGroupUpdate.adminsCount > 0 // senderKeys may be empty
-            }
-            SignalServiceProtos.ClosedGroupUpdate.Type.SENDER_KEY_REQUEST -> return true
-            SignalServiceProtos.ClosedGroupUpdate.Type.SENDER_KEY -> return closedGroupUpdate.senderKeysCount > 0
-            else -> return false
-        }
-    }
-
-    public fun handleNewClosedGroup(context: Context, closedGroupUpdate: SignalServiceProtos.ClosedGroupUpdate, senderPublicKey: String) {
-        // Prepare
-        val userPublicKey = TextSecurePreferences.getLocalNumber(context)
-        val sskDatabase = DatabaseFactory.getSSKDatabase(context)
-        // Unwrap the message
-        val groupPublicKey = closedGroupUpdate.groupPublicKey.toByteArray().toHexString()
-        val name = closedGroupUpdate.name
-        val groupPrivateKey = closedGroupUpdate.groupPrivateKey.toByteArray()
-        val senderKeys = closedGroupUpdate.senderKeysList.map {
-            ClosedGroupSenderKey(it.chainKey.toByteArray(), it.keyIndex, it.publicKey.toByteArray())
-        }
-        val members = closedGroupUpdate.membersList.map { it.toByteArray().toHexString() }
-        val admins = closedGroupUpdate.adminsList.map { it.toByteArray().toHexString() }
-        // Persist the ratchets
-        senderKeys.forEach { senderKey ->
-            if (!members.contains(senderKey.publicKey.toHexString())) { return@forEach }
-            val ratchet = ClosedGroupRatchet(senderKey.chainKey.toHexString(), senderKey.keyIndex, listOf())
-            sskDatabase.setClosedGroupRatchet(groupPublicKey, senderKey.publicKey.toHexString(), ratchet, ClosedGroupRatchetCollectionType.Current)
-        }
-        // Sort out any discrepancies between the provided sender keys and what's required
-        val missingSenderKeys = members.toSet().subtract(senderKeys.map { Hex.toStringCondensed(it.publicKey) })
-        if (missingSenderKeys.contains(userPublicKey)) {
-            establishSessionsWithMembersIfNeeded(context, members)
-            val userRatchet = SharedSenderKeysImplementation.shared.generateRatchet(groupPublicKey, userPublicKey)
-            val userSenderKey = ClosedGroupSenderKey(Hex.fromStringCondensed(userRatchet.chainKey), userRatchet.keyIndex, Hex.fromStringCondensed(userPublicKey))
-            for (member in members) {
-                if (member == userPublicKey) { continue }
-                @Suppress("NAME_SHADOWING")
-                val closedGroupUpdateKind = ClosedGroupUpdateMessageSendJob.Kind.SenderKey(Hex.fromStringCondensed(groupPublicKey), userSenderKey)
-                @Suppress("NAME_SHADOWING")
-                val job = ClosedGroupUpdateMessageSendJob(member, closedGroupUpdateKind)
-                ApplicationContext.getInstance(context).jobManager.add(job)
-            }
-        }
-        for (publicKey in missingSenderKeys.minus(userPublicKey)) {
-            requestSenderKey(context, groupPublicKey, publicKey)
-        }
-        // Create the group
-        val groupID = doubleEncodeGroupID(groupPublicKey)
-        val groupDB = DatabaseFactory.getGroupDatabase(context)
-        if (groupDB.getGroup(groupID).orNull() != null) {
-            // Update the group
-            groupDB.updateTitle(groupID, name)
-            groupDB.updateMembers(groupID, members.map { Address.fromSerialized(it) })
-        } else {
-            groupDB.create(groupID, name, LinkedList<Address>(members.map { Address.fromSerialized(it) }),
-                null, null, LinkedList<Address>(admins.map { Address.fromSerialized(it) }))
-        }
-        DatabaseFactory.getRecipientDatabase(context).setProfileSharing(Recipient.from(context, Address.fromSerialized(groupID), false), true)
-        // Add the group to the user's set of public keys to poll for
-        sskDatabase.setClosedGroupPrivateKey(groupPublicKey, groupPrivateKey.toHexString())
-        // Notify the user
-        insertIncomingInfoMessage(context, senderPublicKey, groupID, GroupContext.Type.UPDATE, SignalServiceGroup.Type.UPDATE, name, members, admins)
-        // Establish sessions if needed
-        establishSessionsWithMembersIfNeeded(context, members)
-        // Notify the PN server
-        LokiPushNotificationManager.performOperation(context, ClosedGroupOperation.Subscribe, groupPublicKey, userPublicKey)
-    }
-
-    public fun handleClosedGroupUpdate(context: Context, closedGroupUpdate: SignalServiceProtos.ClosedGroupUpdate, senderPublicKey: String) {
-        // Prepare
-        val userPublicKey = TextSecurePreferences.getLocalNumber(context)
-        val sskDatabase = DatabaseFactory.getSSKDatabase(context)
-        // Unwrap the message
-        val groupPublicKey = closedGroupUpdate.groupPublicKey.toByteArray().toHexString()
-        val name = closedGroupUpdate.name
-        val senderKeys = closedGroupUpdate.senderKeysList.map {
-            ClosedGroupSenderKey(it.chainKey.toByteArray(), it.keyIndex, it.publicKey.toByteArray())
-        }
-        val members = closedGroupUpdate.membersList.map { it.toByteArray().toHexString() }
-        val admins = closedGroupUpdate.adminsList.map { it.toByteArray().toHexString() }
-        val groupDB = DatabaseFactory.getGroupDatabase(context)
-        val groupID = doubleEncodeGroupID(groupPublicKey)
-        val group = groupDB.getGroup(groupID).orNull()
-        if (group == null) {
-            Log.d("Loki", "Ignoring closed group info message for nonexistent group.")
-            return
-        }
-        val oldMembers = group.members.map { it.serialize() }
-        // Check that the sender is a member of the group (before the update)
-        if (!oldMembers.contains(senderPublicKey)) {
-            Log.d("Loki", "Ignoring closed group info message from non-member.")
-            return
-        }
-        // Store the ratchets for any new members (it's important that this happens before the code below)
-        senderKeys.forEach { senderKey ->
-            val ratchet = ClosedGroupRatchet(senderKey.chainKey.toHexString(), senderKey.keyIndex, listOf())
-            sskDatabase.setClosedGroupRatchet(groupPublicKey, senderKey.publicKey.toHexString(), ratchet, ClosedGroupRatchetCollectionType.Current)
-        }
-        // Delete all ratchets and either:
-        // • Send out the user's new ratchet using established channels if other members of the group left or were removed
-        // • Remove the group from the user's set of public keys to poll for if the current user was among the members that were removed
-        val wasCurrentUserRemoved = !members.contains(userPublicKey)
-        val wasAnyUserRemoved = members.toSet().intersect(oldMembers) != oldMembers.toSet()
-        val wasSenderRemoved = !members.contains(senderPublicKey)
-        if (wasAnyUserRemoved) {
-            val allOldRatchets = sskDatabase.getAllClosedGroupRatchets(groupPublicKey, ClosedGroupRatchetCollectionType.Current)
-            for (pair in allOldRatchets) {
-                @Suppress("NAME_SHADOWING") val senderPublicKey = pair.first
-                val ratchet = pair.second
-                val collection = ClosedGroupRatchetCollectionType.Old
-                sskDatabase.setClosedGroupRatchet(groupPublicKey, senderPublicKey, ratchet, collection)
-            }
-            sskDatabase.removeAllClosedGroupRatchets(groupPublicKey, ClosedGroupRatchetCollectionType.Current)
-            if (wasCurrentUserRemoved) {
-                sskDatabase.removeClosedGroupPrivateKey(groupPublicKey)
-                groupDB.setActive(groupID, false)
-                groupDB.removeMember(groupID, Address.fromSerialized(userPublicKey))
-                // Notify the PN server
-                LokiPushNotificationManager.performOperation(context, ClosedGroupOperation.Unsubscribe, groupPublicKey, userPublicKey)
-            } else {
-                establishSessionsWithMembersIfNeeded(context, members)
-                val userRatchet = SharedSenderKeysImplementation.shared.generateRatchet(groupPublicKey, userPublicKey)
-                val userSenderKey = ClosedGroupSenderKey(Hex.fromStringCondensed(userRatchet.chainKey), userRatchet.keyIndex, Hex.fromStringCondensed(userPublicKey))
-                for (member in members) {
-                    if (member == userPublicKey) { continue }
-                    val closedGroupUpdateKind = ClosedGroupUpdateMessageSendJob.Kind.SenderKey(Hex.fromStringCondensed(groupPublicKey), userSenderKey)
-                    val job = ClosedGroupUpdateMessageSendJob(member, closedGroupUpdateKind)
-                    ApplicationContext.getInstance(context).jobManager.add(job)
-                }
-            }
-        }
-        // Update the group
-        groupDB.updateTitle(groupID, name)
-        if (!wasCurrentUserRemoved) {
-            // The call below sets isActive to true, so if the user is leaving we have to use groupDB.remove(...) instead
-            groupDB.updateMembers(groupID, members.map { Address.fromSerialized(it) })
-        }
-        // Notify the user
-        val type0 = if (wasSenderRemoved) GroupContext.Type.QUIT else GroupContext.Type.UPDATE
-        val type1 = if (wasSenderRemoved) SignalServiceGroup.Type.QUIT else SignalServiceGroup.Type.UPDATE
-        insertIncomingInfoMessage(context, senderPublicKey, groupID, type0, type1, name, members, admins)
-    }
-
-    public fun handleSenderKeyRequest(context: Context, closedGroupUpdate: SignalServiceProtos.ClosedGroupUpdate, senderPublicKey: String) {
-        // Prepare
-        val userPublicKey = TextSecurePreferences.getLocalNumber(context)
-        val groupPublicKey = closedGroupUpdate.groupPublicKey.toByteArray().toHexString()
-        val groupDB = DatabaseFactory.getGroupDatabase(context)
-        val groupID = doubleEncodeGroupID(groupPublicKey)
-        val group = groupDB.getGroup(groupID).orNull()
-        if (group == null) {
-            Log.d("Loki", "Ignoring closed group sender key request for nonexistent group.")
-            return
-        }
-        // Check that the requesting user is a member of the group
-        if (!group.members.map { it.serialize() }.contains(senderPublicKey)) {
-            Log.d("Loki", "Ignoring closed group sender key request from non-member.")
-            return
-        }
-        // Respond to the request
-        Log.d("Loki", "Responding to sender key request from: $senderPublicKey.")
-        ApplicationContext.getInstance(context).sendSessionRequestIfNeeded(senderPublicKey)
-        val userRatchet = DatabaseFactory.getSSKDatabase(context).getClosedGroupRatchet(groupPublicKey, userPublicKey, ClosedGroupRatchetCollectionType.Current)
-            ?: SharedSenderKeysImplementation.shared.generateRatchet(groupPublicKey, userPublicKey)
-        val userSenderKey = ClosedGroupSenderKey(Hex.fromStringCondensed(userRatchet.chainKey), userRatchet.keyIndex, Hex.fromStringCondensed(userPublicKey))
-        val closedGroupUpdateKind = ClosedGroupUpdateMessageSendJob.Kind.SenderKey(Hex.fromStringCondensed(groupPublicKey), userSenderKey)
-        val job = ClosedGroupUpdateMessageSendJob(senderPublicKey, closedGroupUpdateKind)
-        ApplicationContext.getInstance(context).jobManager.add(job)
-    }
-
-    public fun handleSenderKey(context: Context, closedGroupUpdate: SignalServiceProtos.ClosedGroupUpdate, senderPublicKey: String) {
-        // Prepare
-        val sskDatabase = DatabaseFactory.getSSKDatabase(context)
-        val groupPublicKey = closedGroupUpdate.groupPublicKey.toByteArray().toHexString()
-        val senderKeyProto = closedGroupUpdate.senderKeysList.firstOrNull()
-        if (senderKeyProto == null) {
-            Log.d("Loki", "Ignoring invalid closed group sender key.")
-            return
-        }
-        val senderKey = ClosedGroupSenderKey(senderKeyProto.chainKey.toByteArray(), senderKeyProto.keyIndex, senderKeyProto.publicKey.toByteArray())
-        if (senderKeyProto.publicKey.toByteArray().toHexString() != senderPublicKey) {
-            Log.d("Loki", "Ignoring invalid closed group sender key.")
-            return
-        }
-        // Store the sender key
-        Log.d("Loki", "Received a sender key from: $senderPublicKey.")
-        val ratchet = ClosedGroupRatchet(senderKey.chainKey.toHexString(), senderKey.keyIndex, listOf())
-        sskDatabase.setClosedGroupRatchet(groupPublicKey, senderPublicKey, ratchet, ClosedGroupRatchetCollectionType.Current)
     }
 
     @JvmStatic
@@ -546,21 +287,6 @@ object ClosedGroupsProtocol {
         }
     }
 
-    private fun insertIncomingInfoMessage(context: Context, senderPublicKey: String, groupID: String, type0: GroupContext.Type, type1: SignalServiceGroup.Type,
-        name: String, members: Collection<String>, admins: Collection<String>) {
-        val groupContextBuilder = GroupContext.newBuilder()
-            .setId(ByteString.copyFrom(GroupUtil.getDecodedId(groupID)))
-            .setType(type0)
-            .setName(name)
-            .addAllMembers(members)
-            .addAllAdmins(admins)
-        val group = SignalServiceGroup(type1, GroupUtil.getDecodedId(groupID), GroupType.SIGNAL, name, members.toList(), null, admins.toList())
-        val m = IncomingTextMessage(Address.fromSerialized(senderPublicKey), 1, System.currentTimeMillis(), "", Optional.of(group), 0, true)
-        val infoMessage = IncomingGroupMessage(m, groupContextBuilder.build(), "")
-        val smsDB = DatabaseFactory.getSmsDatabase(context)
-        smsDB.insertMessageInbox(infoMessage)
-    }
-
     private fun insertOutgoingInfoMessage(context: Context, groupID: String, type: GroupContext.Type, name: String,
         members: Collection<String>, admins: Collection<String>, threadID: Long) {
         val recipient = Recipient.from(context, Address.fromSerialized(groupID), false)
@@ -580,13 +306,13 @@ object ClosedGroupsProtocol {
 
     @JvmStatic
     @Throws(IOException::class)
-    public fun doubleEncodeGroupID(groupPublicKey: String): String {
+    fun doubleEncodeGroupID(groupPublicKey: String): String {
         return GroupUtil.getEncodedId(GroupUtil.getEncodedId(Hex.fromStringCondensed(groupPublicKey), false).toByteArray(), false)
     }
 
     @JvmStatic
     @Throws(IOException::class)
-    public fun doubleDecodeGroupID(groupID: String): ByteArray {
+    fun doubleDecodeGroupID(groupID: String): ByteArray {
         return GroupUtil.getDecodedId(GroupUtil.getDecodedStringId(groupID))
     }
 }

--- a/src/org/thoughtcrime/securesms/loki/protocol/ClosedGroupsProtocolV2.kt
+++ b/src/org/thoughtcrime/securesms/loki/protocol/ClosedGroupsProtocolV2.kt
@@ -42,7 +42,7 @@ import java.util.*
 import kotlin.jvm.Throws
 
 object ClosedGroupsProtocolV2 {
-    val groupSizeLimit = 20
+    const val groupSizeLimit = 100
 
     sealed class Error(val description: String) : Exception() {
         object NoThread : Error("Couldn't find a thread associated with the given group public key")


### PR DESCRIPTION
refactor!: increase closed group limit to 100

BREAKING CHANGE: if older client users are added to a >20 size closed group they probably won't be able to edit group members without receiving errors

remove legacy references to ClosedGroupsProtocol.kt, update translations for CreateClosedGroupActivity.kt