### PR TITLE
refactor: use the more translated string for max group members

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1842,7 +1842,6 @@
     <string name="activity_edit_closed_group_group_name_missing_error">Group name can\'t be empty</string>
     <string name="activity_edit_closed_group_group_name_too_long_error">Please enter a shorter group name</string>
     <string name="activity_edit_closed_group_not_enough_group_members_error">Groups must have at least 1 group member</string>
-    <string name="activity_edit_closed_group_too_many_group_members_error">A closed group cannot have more than 10 members</string>
     <string name="activity_edit_closed_group_invalid_session_id_error">One of the members of your group has an invalid Session ID</string>
     <string name="activity_edit_closed_group_confirm_removal">Are you sure you want to remove this user?</string>
     <string name="activity_edit_closed_group_member_removed">User removed from group</string>

--- a/src/org/thoughtcrime/securesms/loki/activities/EditClosedGroupActivity.kt
+++ b/src/org/thoughtcrime/securesms/loki/activities/EditClosedGroupActivity.kt
@@ -239,14 +239,13 @@ class EditClosedGroupActivity : PassphraseRequiredActionBarActivity() {
             isSSKBasedClosedGroup = false
         }
 
-        if (members.size < 1) {
+        if (members.isEmpty()) {
             return Toast.makeText(this, R.string.activity_edit_closed_group_not_enough_group_members_error, Toast.LENGTH_LONG).show()
         }
 
         val maxGroupMembers = if (isSSKBasedClosedGroup) ClosedGroupsProtocolV2.groupSizeLimit else legacyGroupSizeLimit
         if (members.size >= maxGroupMembers) {
-            // TODO: Update copy for SSK based closed groups
-            return Toast.makeText(this, R.string.activity_edit_closed_group_too_many_group_members_error, Toast.LENGTH_LONG).show()
+            return Toast.makeText(this, R.string.activity_create_closed_group_too_many_group_members_error, Toast.LENGTH_LONG).show()
         }
 
         val userPublicKey = TextSecurePreferences.getLocalNumber(this)


### PR DESCRIPTION
Remove strings.xml single reference to the edit activity too many group members, EditClosedGroupActivity.kt now uses the same localised versions as the create closed group logic