### PR TITLE
up java memory to prevent lint running out

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 android.useAndroidX=true
 android.enableJetifier=true
-org.gradle.jvmargs=-Xmx2048m
+org.gradle.jvmargs=-Xmx4096m


### PR DESCRIPTION
This prevents a build crash due to memory exhaustion on some systems.

See https://stackoverflow.com/questions/46970728/android-build-tools-26-0-2-out-of-memory-lint