### PR TITLE
Group explicit leave flag, docs, null fix

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/loki/activities/EditClosedGroupActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/loki/activities/EditClosedGroupActivity.kt
@@ -298,7 +298,7 @@ class EditClosedGroupActivity : PassphraseRequiredActionBarActivity() {
             }.failUi { exception ->
                 val message = if (exception is ClosedGroupsProtocol.Error) exception.description else "An error occurred"
                 Toast.makeText(this@EditClosedGroupActivity, message, Toast.LENGTH_LONG).show()
-                loader.fadeOut()
+                loaderContainer.fadeOut()
                 isLoading = false
             }
         } else {

--- a/app/src/main/java/org/thoughtcrime/securesms/loki/activities/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/loki/activities/HomeActivity.kt
@@ -358,7 +358,7 @@ class HomeActivity : PassphraseRequiredActionBarActivity, ConversationClickListe
                     isSSKBasedClosedGroup = false
                 }
                 if (isSSKBasedClosedGroup) {
-                    ClosedGroupsProtocolV2.explicitLeave(context, groupPublicKey!!)
+                    ClosedGroupsProtocolV2.explicitLeave(context, groupPublicKey!!, notifyUser = false)
                 } else if (!ClosedGroupsProtocol.leaveLegacyGroup(context, recipient)) {
                     Toast.makeText(context, R.string.activity_home_leaving_group_failed_message, Toast.LENGTH_LONG).show()
                     return@launch

--- a/app/src/main/java/org/thoughtcrime/securesms/loki/protocol/ClosedGroupsProtocolV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/loki/protocol/ClosedGroupsProtocolV2.kt
@@ -94,6 +94,10 @@ object ClosedGroupsProtocolV2 {
         return deferred.promise
     }
 
+    /**
+     * @param notifyUser Inserts an outgoing info message for the user's leave message, useful to set `false` if
+     * you are exiting asynchronously and deleting the thread from [HomeActivity][org.thoughtcrime.securesms.loki.activities.HomeActivity.deleteConversation]
+     */
     @JvmStatic @JvmOverloads
     fun explicitLeave(context: Context, groupPublicKey: String, notifyUser: Boolean = true): Promise<Unit, Exception> {
         val deferred = deferred<Unit, Exception>()

--- a/app/src/main/java/org/thoughtcrime/securesms/loki/protocol/ClosedGroupsProtocolV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/loki/protocol/ClosedGroupsProtocolV2.kt
@@ -145,9 +145,7 @@ object ClosedGroupsProtocolV2 {
         val admins = group.admins.map { it.serialize() }
         val adminsAsData = admins.map { Hex.fromStringCondensed(it) }
         val sentTime = System.currentTimeMillis()
-        val encryptionKeyPair = pendingKeyPair.getOrElse(groupPublicKey) {
-            Optional.fromNullable(apiDB.getLatestClosedGroupEncryptionKeyPair(groupPublicKey))
-        }.orNull()
+        val encryptionKeyPair = pendingKeyPair[groupPublicKey]?.orNull() ?: Optional.fromNullable(apiDB.getLatestClosedGroupEncryptionKeyPair(groupPublicKey)).orNull()
         if (encryptionKeyPair == null) {
             Log.d("Loki", "Couldn't get encryption key pair for closed group.")
             throw Error.NoKeyPair

--- a/app/src/main/java/org/thoughtcrime/securesms/loki/protocol/ClosedGroupsProtocolV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/loki/protocol/ClosedGroupsProtocolV2.kt
@@ -518,7 +518,7 @@ object ClosedGroupsProtocolV2 {
         val userLeft = userPublicKey == senderPublicKey
 
         // if the admin left, we left, or we are the only remaining member: remove the group
-        if (didAdminLeave || userLeft || updatedMemberList.size == 1) {
+        if (didAdminLeave || userLeft) {
             disableLocalGroupAndUnsubscribe(context, apiDB, groupPublicKey, groupDB, groupID, userPublicKey)
         } else {
             val isCurrentUserAdmin = admins.contains(userPublicKey)

--- a/app/src/main/java/org/thoughtcrime/securesms/loki/protocol/ClosedGroupsProtocolV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/loki/protocol/ClosedGroupsProtocolV2.kt
@@ -94,8 +94,8 @@ object ClosedGroupsProtocolV2 {
         return deferred.promise
     }
 
-    @JvmStatic
-    fun explicitLeave(context: Context, groupPublicKey: String): Promise<Unit, Exception> {
+    @JvmStatic @JvmOverloads
+    fun explicitLeave(context: Context, groupPublicKey: String, notifyUser: Boolean = true): Promise<Unit, Exception> {
         val deferred = deferred<Unit, Exception>()
         ThreadUtils.queue {
             val userPublicKey = TextSecurePreferences.getLocalNumber(context)!!
@@ -119,7 +119,9 @@ object ClosedGroupsProtocolV2 {
             // Notify the user
             val infoType = GroupContext.Type.QUIT
             val threadID = DatabaseFactory.getThreadDatabase(context).getOrCreateThreadIdFor(Recipient.from(context, Address.fromSerialized(groupID), false))
-            insertOutgoingInfoMessage(context, groupID, infoType, name, updatedMembers, admins, threadID, sentTime)
+            if (notifyUser) {
+                insertOutgoingInfoMessage(context, groupID, infoType, name, updatedMembers, admins, threadID, sentTime)
+            }
             // Remove the group private key and unsubscribe from PNs
             disableLocalGroupAndUnsubscribe(context, apiDB, groupPublicKey, groupDB, groupID, userPublicKey)
             deferred.resolve(Unit)


### PR DESCRIPTION
Add an explicit leave notifyUser flag to prevent deletes from coming up after asynchronously arriving with success, fix the ConcurrentHashMap's getting null optional value