### PR TITLE
Initial fixes to Japanese translations

### DIFF
--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -28,7 +28,7 @@
   <string name="ApplicationPreferencesActivity_unregistering">登録取り消し</string>
   <string name="ApplicationPreferencesActivity_unregistering_from_signal_messages_and_calls">Sessionの登録を解除します...</string>
   <string name="ApplicationPreferencesActivity_disable_signal_messages_and_calls">Sessionでのメッセージ・通話を無効にしますか？</string>
-  <string name="ApplicationPreferencesActivity_disable_signal_messages_and_calls_by_unregistering">サーバーから登録を取消します。Signalを使ったメッセージのやり取りや通話はできなくなります。 再びSessionを使うためには、あなたの電話番号を再登録をする必要があります。</string>
+  <string name="ApplicationPreferencesActivity_disable_signal_messages_and_calls_by_unregistering">サーバーから登録を取消します。Sessionを使ったメッセージのやり取りや通話はできなくなります。 再びSessionを使うためには、あなたの電話番号を再登録をする必要があります。</string>
   <string name="ApplicationPreferencesActivity_error_connecting_to_server">サーバー接続中にエラーが発生しました！</string>
   <string name="ApplicationPreferencesActivity_sms_enabled">SMS 有効</string>
   <string name="ApplicationPreferencesActivity_touch_to_change_your_default_sms_app">タッチしてデフォルトのSMSアプリを変更</string>
@@ -286,7 +286,7 @@
   <string name="GcmBroadcastReceiver_retrieving_a_message">メッセージを読み込んでいます...</string>
   <!--GcmRefreshJob-->
   <string name="GcmRefreshJob_Permanent_Signal_communication_failure">永続的なSession通信のエラー！</string>
-  <string name="GcmRefreshJob_Signal_was_unable_to_register_with_Google_Play_Services">Google PlayサービスにSignalを登録できなかったため、Sessionのメッセージと通話は無効になっています。設定 &gt; 詳細設定で再登録を試してください。</string>
+  <string name="GcmRefreshJob_Signal_was_unable_to_register_with_Google_Play_Services">Google PlayサービスにSessionを登録できなかったため、Sessionのメッセージと通話は無効になっています。設定 &gt; 詳細設定で再登録を試してください。</string>
   <!--GiphyActivity-->
   <string name="GiphyActivity_error_while_retrieving_full_resolution_gif">GIFファイルの取り込みでエラー</string>
   <!--GiphyFragmentPageAdapter-->
@@ -298,7 +298,7 @@
   <string name="GroupCreateActivity_group_name_hint">グループ名</string>
   <string name="GroupCreateActivity_actionbar_mms_title">新規MMSグループ</string>
   <string name="GroupCreateActivity_contacts_dont_support_push">Sessionユーザーでない人がいるため、このグループはMMSとなります。</string>
-  <string name="GroupCreateActivity_youre_not_registered_for_signal">Signalに未登録のためSessionグループを利用できません。設定 &gt; 詳細設定で再登録を試してください。</string>
+  <string name="GroupCreateActivity_youre_not_registered_for_signal">Sessionに未登録のためSessionグループを利用できません。設定 &gt; 詳細設定で再登録を試してください。</string>
   <string name="GroupCreateActivity_contacts_no_members">グループには最低でも１人は必要です！</string>
   <string name="GroupCreateActivity_contacts_invalid_number">グループのメンバーで電話番号が正しくない人がいます。番号を修正するか、そのメンバーを削除してからやり直してください。</string>
   <string name="GroupCreateActivity_avatar_content_description">グループアバター</string>
@@ -390,7 +390,7 @@
   <!--MediaRepository-->
   <string name="MediaRepository_all_media">すべてのメディア</string>
   <!--MessageRecord-->
-  <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">受信したメッセージは古いSignalで暗号化されているので解読不能です。Sessionをアップデートして再送するよう送信者にお願いしてください。</string>
+  <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">受信したメッセージは古いSessionで暗号化されているので解読不能です。Sessionをアップデートして再送するよう送信者にお願いしてください。</string>
   <string name="MessageRecord_left_group">グループを抜けました</string>
   <string name="MessageRecord_you_updated_group">グループを更新しました</string>
   <string name="MessageRecord_you_called">発信</string>
@@ -572,8 +572,8 @@
   <string name="UnverifiedSendDialog_send_message">送信しますか？</string>
   <string name="UnverifiedSendDialog_send">送信</string>
   <!--VerifyIdentityActivity-->
-  <string name="VerifyIdentityActivity_your_contact_is_running_an_old_version_of_signal">連絡先の相手は古いSignalを使っています。Sessionをアップデートしてから安全番号の検証を行うようお願いしてください。</string>
-  <string name="VerifyIdentityActivity_your_contact_is_running_a_newer_version_of_Signal">相手がより新しいバージョンのSignalを使ってるため，QRコードの形式が異なります。Sessionをアップデートしてから改めて比較してください。</string>
+  <string name="VerifyIdentityActivity_your_contact_is_running_an_old_version_of_signal">連絡先の相手は古いSessionを使っています。Sessionをアップデートしてから安全番号の検証を行うようお願いしてください。</string>
+  <string name="VerifyIdentityActivity_your_contact_is_running_a_newer_version_of_Signal">相手がより新しいバージョンのSessionを使ってるため，QRコードの形式が異なります。Sessionをアップデートしてから改めて比較してください。</string>
   <string name="VerifyIdentityActivity_the_scanned_qr_code_is_not_a_correctly_formatted_safety_number">読み取ったQRコードは、適正な安全番号認証コードではありません。もう一度読み取って下さい。</string>
   <string name="VerifyIdentityActivity_share_safety_number_via">次の方法で安全番号を共有...</string>
   <string name="VerifyIdentityActivity_our_signal_safety_number">私たちの安全番号:</string>
@@ -878,7 +878,7 @@
   <string name="redphone_call_controls__flip_camera_rear">カメラを切り替える</string>
   <!--registration_activity-->
   <string name="registration_activity__phone_number">電話番号</string>
-  <string name="registration_activity__registration_will_transmit_some_contact_information_to_the_server_temporariliy">コミュニケーションを簡単にするために、Signalはあなたの連絡先の電話番号を活用します。あなたの電話番号を以前から知っている人はSessionを使って簡単にあなたに連絡することができます。\n\n登録を行うと連絡先に関する情報の一部がサーバーに送信されますが、保存はされません。</string>
+  <string name="registration_activity__registration_will_transmit_some_contact_information_to_the_server_temporariliy">コミュニケーションを簡単にするために、Sessionはあなたの連絡先の電話番号を活用します。あなたの電話番号を以前から知っている人はSessionを使って簡単にあなたに連絡することができます。\n\n登録を行うと連絡先に関する情報の一部がサーバーに送信されますが、保存はされません。</string>
   <string name="registration_activity__verify_your_number">番号を確認する</string>
   <string name="registration_activity__please_enter_your_mobile_number_to_receive_a_verification_code_carrier_rates_may_apply">自分の電話番号を入力して、認証コードを取得してください。通信会社の料金がかかる場合があります。</string>
   <!--recipients_panel-->
@@ -1135,7 +1135,7 @@
   <!--reminder_header-->
   <string name="reminder_header_outdated_build">Sessionのバージョンが古すぎます</string>
   <plurals name="reminder_header_outdated_build_details">
-    <item quantity="other">このバージョンのSignalは%d日後に期限が切れます。タップしてSessionをアプデートしてお願いします。</item>
+    <item quantity="other">このバージョンのSessionは%d日後に期限が切れます。タップしてSessionをアプデートしてお願いします。</item>
   </plurals>
   <string name="reminder_header_outdated_build_details_today">このバージョンのSessionは本日で期限切れとなります。タップして最新版にアップデートしてください。</string>
   <string name="reminder_header_expired_build">このバージョンのSessionは期限切れになりました</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -304,7 +304,7 @@
   <string name="GroupCreateActivity_avatar_content_description">グループアバター</string>
   <string name="GroupCreateActivity_menu_apply_button">適用する</string>
   <string name="GroupCreateActivity_creating_group">%1$sを作成中...</string>
-  <string name="GroupCreateActivity_updating_group">%1$sをアップデート中...</string>
+  <string name="GroupCreateActivity_updating_group">%1$sを更新中...</string>
   <string name="GroupCreateActivity_cannot_add_non_push_to_existing_group">Sessionユーザーでないので%1$sを加えることはできません</string>
   <string name="GroupCreateActivity_loading_group_details">グループ詳細を読み込み...</string>
   <string name="GroupCreateActivity_youre_already_in_the_group">グループに加入済みです</string>
@@ -390,7 +390,7 @@
   <!--MediaRepository-->
   <string name="MediaRepository_all_media">すべてのメディア</string>
   <!--MessageRecord-->
-  <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">受信したメッセージは古いSessionで暗号化されているので解読不能です。Sessionをアップデートして再送するよう送信者にお願いしてください。</string>
+  <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">受信したメッセージは古いSessionで暗号化されているので解読不能です。Sessionを更新して再送するよう送信者にお願いしてください。</string>
   <string name="MessageRecord_left_group">グループを抜けました</string>
   <string name="MessageRecord_you_updated_group">グループを更新しました</string>
   <string name="MessageRecord_you_called">発信</string>
@@ -556,8 +556,8 @@
   <string name="ThreadRecord_you_marked_verified">検証済みにしました</string>
   <string name="ThreadRecord_you_marked_unverified">未検証にしました</string>
   <!--UpdateApkReadyListener-->
-  <string name="UpdateApkReadyListener_Signal_update">Sessionをアップデートする</string>
-  <string name="UpdateApkReadyListener_a_new_version_of_signal_is_available_tap_to_update">Sessionの最新版が出ました。タップしてアップデートしてください。</string>
+  <string name="UpdateApkReadyListener_Signal_update">Sessionを更新する</string>
+  <string name="UpdateApkReadyListener_a_new_version_of_signal_is_available_tap_to_update">Sessionの最新版が出ました。タップして更新してください。</string>
   <!--UnknownSenderView-->
   <string name="UnknownSenderView_block_s">%sをブロックしますか？</string>
   <string name="UnknownSenderView_blocked_contacts_will_no_longer_be_able_to_send_you_messages_or_call_you">ブロックされた相手はあなたにメッセージを送ることも電話を掛けることもできなくなります。</string>
@@ -572,8 +572,8 @@
   <string name="UnverifiedSendDialog_send_message">送信しますか？</string>
   <string name="UnverifiedSendDialog_send">送信</string>
   <!--VerifyIdentityActivity-->
-  <string name="VerifyIdentityActivity_your_contact_is_running_an_old_version_of_signal">連絡先の相手は古いSessionを使っています。Sessionをアップデートしてから安全番号の検証を行うようお願いしてください。</string>
-  <string name="VerifyIdentityActivity_your_contact_is_running_a_newer_version_of_Signal">相手がより新しいバージョンのSessionを使ってるため，QRコードの形式が異なります。Sessionをアップデートしてから改めて比較してください。</string>
+  <string name="VerifyIdentityActivity_your_contact_is_running_an_old_version_of_signal">連絡先の相手は古いSessionを使っています。Sessionを更新してから安全番号の検証を行うようお願いしてください。</string>
+  <string name="VerifyIdentityActivity_your_contact_is_running_a_newer_version_of_Signal">相手がより新しいバージョンのSessionを使っているため，QRコードの形式が異なります。Sessionを更新してから改めて比較してください。</string>
   <string name="VerifyIdentityActivity_the_scanned_qr_code_is_not_a_correctly_formatted_safety_number">読み取ったQRコードは、適正な安全番号認証コードではありません。もう一度読み取って下さい。</string>
   <string name="VerifyIdentityActivity_share_safety_number_via">次の方法で安全番号を共有...</string>
   <string name="VerifyIdentityActivity_our_signal_safety_number">私たちの安全番号:</string>
@@ -1135,11 +1135,11 @@
   <!--reminder_header-->
   <string name="reminder_header_outdated_build">Sessionのバージョンが古すぎます</string>
   <plurals name="reminder_header_outdated_build_details">
-    <item quantity="other">このバージョンのSessionは%d日後に期限が切れます。タップしてSessionをアプデートしてお願いします。</item>
+    <item quantity="other">このバージョンのSessionは%d日後に期限が切れます。タップしてSessionを更新してください。</item>
   </plurals>
-  <string name="reminder_header_outdated_build_details_today">このバージョンのSessionは本日で期限切れとなります。タップして最新版にアップデートしてください。</string>
+  <string name="reminder_header_outdated_build_details_today">このバージョンのSessionは本日で期限切れとなります。タップして最新版に更新してください。</string>
   <string name="reminder_header_expired_build">このバージョンのSessionは期限切れになりました</string>
-  <string name="reminder_header_expired_build_details">メッセージを送ることができなくなりました。タップして最新版にアップデートしてください。</string>
+  <string name="reminder_header_expired_build_details">メッセージを送ることができなくなりました。タップして最新版に更新してください。</string>
   <string name="reminder_header_sms_default_title">既定のSMSアプリにする</string>
   <string name="reminder_header_sms_default_text">タップしてSessionを既定のSMSアプリに設定する</string>
   <string name="reminder_header_sms_import_title">システムのSMSをインポート</string>
@@ -1151,7 +1151,7 @@
   <string name="reminder_header_share_title">友達にオススメしよう！</string>
   <string name="reminder_header_share_text">ユーザが増やせば増やすほど、Sessionはより便利になります</string>
   <string name="reminder_header_service_outage_text">Sessionは技術的な問題を抱えています。私たちは、これをできるだけ早く解決するよう対応しています。</string>
-  <string name="reminder_header_the_latest_signal_features_wont_work">Sessionの最新機能は、このバージョンのAndroidでは対応しなくなります。OSのアップデートをしてください。</string>
+  <string name="reminder_header_the_latest_signal_features_wont_work">Sessionの最新機能は、このバージョンのAndroidでは対応しなくなります。OSの更新をしてください。</string>
   <!--media_preview-->
   <string name="media_preview__save_title">保存</string>
   <string name="media_preview__forward_title">転送</string>
@@ -1180,7 +1180,7 @@
   <string name="SQLCipherMigrationHelper_migrating_signal_database">Sessionのデータを移行する</string>
   <string name="PushDecryptJob_new_locked_message">ロックされた新着メッセージ</string>
   <string name="PushDecryptJob_unlock_to_view_pending_messages">ロックを外し、メッセージを見る</string>
-  <string name="ExperienceUpgradeActivity_unlock_to_complete_update">ロックを外し、更新を完了する</string>
+  <string name="ExperienceUpgradeActivity_unlock_to_complete_update">ロックを解除し、更新を完了する</string>
   <string name="ExperienceUpgradeActivity_please_unlock_signal_to_complete_update">更新を完了するため、ロックを解除してください</string>
   <string name="enter_backup_passphrase_dialog__backup_passphrase">バックアップ用パスフレーズ </string>
   <string name="backup_enable_dialog__backups_will_be_saved_to_external_storage_and_encrypted_with_the_passphrase_below_you_must_have_this_passphrase_in_order_to_restore_a_backup">バックアップは外部ストレージにパスフレーズで暗号化して保存されます。バックアップのリストアには、このパスフレーズが必要です。</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -240,14 +240,14 @@
   <string name="DeliveryStatus_read">既読</string>
   <!--DeviceListActivity-->
   <string name="DeviceListActivity_unlink_s">\'%s\' のリンクを解除しますか？</string>
-  <string name="DeviceListActivity_by_unlinking_this_device_it_will_no_longer_be_able_to_send_or_receive">このデバイスを切り離すとメッセージの送受信ができなくなります。</string>
+  <string name="DeviceListActivity_by_unlinking_this_device_it_will_no_longer_be_able_to_send_or_receive">この端末のリンクを解除するとメッセージの送受信ができなくなります。</string>
   <string name="DeviceListActivity_network_connection_failed">ネットワーク接続に失敗</string>
   <string name="DeviceListActivity_try_again">再試行</string>
-  <string name="DeviceListActivity_unlinking_device">デバイスを切り離す...</string>
-  <string name="DeviceListActivity_unlinking_device_no_ellipsis">デバイスを切り離す</string>
+  <string name="DeviceListActivity_unlinking_device">端末のリンクを解除中...</string>
+  <string name="DeviceListActivity_unlinking_device_no_ellipsis">端末のリンクを解除中</string>
   <string name="DeviceListActivity_network_failed">ネットワークエラー！</string>
   <!--DeviceListItem-->
-  <string name="DeviceListItem_unnamed_device">無名のデバイス</string>
+  <string name="DeviceListItem_unnamed_device">無名の端末</string>
   <string name="DeviceListItem_linked_s">%sをリンクしました</string>
   <string name="DeviceListItem_last_active_s">最後の活動%s</string>
   <string name="DeviceListItem_today">今日</string>
@@ -451,7 +451,7 @@
   <string name="RatingManager_rate_now">評価する！</string>
   <string name="RatingManager_no_thanks">しません</string>
   <string name="RatingManager_later">後で</string>
-  <string name="RatingManager_whoops_the_play_store_app_does_not_appear_to_be_installed">おっと、Playストアアプリはこのデバイスにインストールされていないようです。</string>
+  <string name="RatingManager_whoops_the_play_store_app_does_not_appear_to_be_installed">おっと、Playストアアプリはこの端末にインストールされていないようです。</string>
   <!--RecipientPreferencesActivity-->
   <string name="RecipientPreferenceActivity_block_this_contact_question">この連絡先をブロックしますか？</string>
   <string name="RecipientPreferenceActivity_you_will_no_longer_receive_messages_and_calls_from_this_contact">この連絡先からのメッセージや通話を受信できなくなります。</string>
@@ -801,7 +801,7 @@
   <!--giphy_fragment-->
   <string name="giphy_fragment__nothing_found">何も見つかりませんでした</string>
   <!--log_submit_activity-->
-  <string name="log_submit_activity__log_fetch_failed">デバイス上のログを読めません。ただしADBを使ってデバッグログを読むことはできます。</string>
+  <string name="log_submit_activity__log_fetch_failed">端末上のログを読めません。ただしADBを使ってデバッグログを読むことはできます。</string>
   <string name="log_submit_activity__thanks">ご協力ありがとうございます！</string>
   <string name="log_submit_activity__submitting">送信中</string>
   <string name="log_submit_activity__no_browser_installed">ブラウザがインストールされていません</string>
@@ -850,7 +850,7 @@
   <!--prompt_passphrase_activity-->
   <string name="prompt_passphrase_activity__unlock">ロック解除</string>
   <!--prompt_mms_activity-->
-  <string name="prompt_mms_activity__signal_requires_mms_settings_to_deliver_media_and_group_messages">グループメッセージや画像等を携帯電話回線を使って送るようMMSの設定をする必要がありますが、このデバイスの設定情報が不明です。これはデバイスにロックや制限が掛かっている場合に起こることがあります。</string>
+  <string name="prompt_mms_activity__signal_requires_mms_settings_to_deliver_media_and_group_messages">グループメッセージや画像等を携帯電話回線を使って送るようMMSの設定をする必要がありますが、この端末の設定情報が不明です。これは端末にロックや制限が掛かっている場合に起こることがあります。</string>
   <string name="prompt_mms_activity__to_send_media_and_group_messages_tap_ok">グループメッセージや画像等を送るには「OK」を押して設定を完了してください。MMSの設定は一般的には「アクセスポイント名」を探すことで見つかります。これは１度行えば十分です。</string>
   <!--profile_create_activity-->
   <string name="profile_create_activity__set_later">後で</string>
@@ -1268,7 +1268,7 @@
   <string name="copy">コピーする</string>
   <string name="invalid_url">URL が無効です</string>
   <string name="copied_to_clipboard">クリップボードにコピーされました</string>
-  <string name="device_linking_failed">デバイスをリンクできませんでした。</string>
+  <string name="device_linking_failed">端末をリンクできませんでした。</string>
   <string name="next">次</string>
   <string name="share">共有する</string>
   <string name="invalid_session_id">Session ID が無効です</string>
@@ -1279,7 +1279,7 @@
   <string name="activity_landing_register_button_title">Session ID を作成する</string>
   <string name="activity_landing_restore_button_title">Session を続ける</string>
   <string name="activity_landing_link_button_title">既存のアカウントにリンクする</string>
-  <string name="activity_landing_device_unlinked_dialog_title">デバイスは正常にリンク解除されました</string>
+  <string name="activity_landing_device_unlinked_dialog_title">端末は正常にリンク解除されました</string>
 
   <string name="view_fake_chat_bubble_1">Session とは？</string>
   <string name="view_fake_chat_bubble_2">分散型の暗号化されたメッセージングアプリです</string>
@@ -1295,13 +1295,13 @@
   <string name="activity_restore_explanation">アカウントを復元するためにサインアップしたときに与えられたリカバリーフレーズを入力します。</string>
   <string name="activity_restore_seed_edit_text_hint">リカバリーフレーズを入力してください</string>
 
-  <string name="activity_link_device_title">デバイスをリンクする</string>
+  <string name="activity_link_device_title">端末をリンクする</string>
   <string name="activity_link_device_enter_session_id_tab_title">Session ID を入力してください</string>
   <string name="activity_link_device_scan_qr_code_tab_title">QR コードをスキャンする</string>
-  <string name="activity_link_device_scan_qr_code_explanation">他のデバイスで [設定]&gt; [デバイス]&gt; [デバイスのリンク] に移動し、表示される QR コードをスキャンして、リンクプロセスを開始します。</string>
+  <string name="activity_link_device_scan_qr_code_explanation">他の端末で「設定」&gt;「端末」&gt;「端末をリンクする」に移動し、表示される QR コードをスキャンして、リンクプロセスを開始します。</string>
 
-  <string name="fragment_enter_session_id_title">デバイスをリンクする</string>
-  <string name="fragment_enter_session_id_explanation">[設定]&gt; [デバイス]&gt; [他のデバイスのデバイスをリンク] に移動し、Session ID を入力して、リンクプロセスを開始します。</string>
+  <string name="fragment_enter_session_id_title">端末をリンクする</string>
+  <string name="fragment_enter_session_id_explanation">「設定」&gt;「端末」&gt;「端末をリンクする」に移動し、Session ID を入力して、リンクプロセスを開始します。</string>
   <string name="fragment_enter_session_id_edit_text_hint">Session ID を入力してください</string>
 
   <string name="activity_display_name_title_2">表示名を選択してください</string>
@@ -1323,7 +1323,7 @@
 
   <string name="activity_seed_title">あなたのリカバリーフレーズ</string>
   <string name="activity_seed_title_2">リカバリーフレーズに合致する</string>
-  <string name="activity_seed_explanation">リカバリーフレーズは、Session ID のマスターキーです。デバイスにアクセスできなくなった場合、これを使用して Session ID を復元できます。リカバリーフレーズを安全な場所に保管し、誰にも教えないでください。</string>
+  <string name="activity_seed_explanation">リカバリーフレーズは、Session ID のマスターキーです。端末にアクセスできなくなった場合、これを使用して Session ID を復元できます。リカバリーフレーズを安全な場所に保管し、誰にも教えないでください。</string>
   <string name="activity_seed_reveal_button_title">明らかにする</string>
 
   <string name="view_seed_reminder_subtitle_1">リカバリーフレーズを保存してアカウントを保護する</string>
@@ -1344,7 +1344,7 @@
   <string name="activity_create_private_chat_scan_qr_code_explanation">ユーザーの QR コードをスキャンして、Session を開始します。QR コードは、アカウント設定の QR コードアイコンをタップすると見つかります。</string>
 
   <string name="fragment_enter_public_key_edit_text_hint">受信者の Session ID を入力してください</string>
-  <string name="fragment_enter_public_key_explanation">ユーザーは、アカウント設定に移動して [Session ID を共有] をタップするか、QR コードを共有することで、Session ID を共有できます。</string>
+  <string name="fragment_enter_public_key_explanation">ユーザーは、アカウント設定に移動して「Session ID を共有」をタップするか、QR コードを共有することで、Session ID を共有できます。</string>
 
   <string name="fragment_scan_qr_code_camera_access_explanation">Session で QR コードをスキャンするにはカメラへのアクセスが必要です</string>
   <string name="fragment_scan_qr_code_grant_camera_access_button_title">カメラへのアクセスを許可する</string>
@@ -1376,7 +1376,7 @@
   <string name="activity_settings_privacy_button_title">プライバシー</string>
   <string name="activity_settings_notifications_button_title">お知らせ</string>
   <string name="activity_settings_chats_button_title">チャット</string>
-  <string name="activity_settings_devices_button_title">デバイス</string>
+  <string name="activity_settings_devices_button_title">端末</string>
   <string name="activity_settings_recovery_phrase_button_title">リカバリーフレーズ</string>
   <string name="activity_settings_clear_all_data_button_title">データを消去する</string>
 
@@ -1388,37 +1388,37 @@
 
   <string name="activity_chat_settings_title">チャット</string>
 
-  <string name="activity_linked_devices_title">デバイス</string>
-  <string name="activity_linked_devices_multi_device_limit_reached_dialog_title">デバイス制限に達しました</string>
-  <string name="activity_linked_devices_multi_device_limit_reached_dialog_explanation">現在、複数のデバイスをリンクすることはできません。</string>
-  <string name="activity_linked_devices_unlinking_failed_message">デバイスのリンクを解除できませんでした。</string>
-  <string name="activity_linked_devices_unlinking_successful_message">デバイスは正常にリンク解除されました</string>
-  <string name="activity_linked_devices_linking_failed_message">デバイスをリンクできませんでした。</string>
-  <string name="activity_linked_devices_empty_state_message">まだデバイスをリンクしていません</string>
-  <string name="activity_linked_devices_empty_state_button_title">デバイスをリンクする（ベータ）</string>
+  <string name="activity_linked_devices_title">端末</string>
+  <string name="activity_linked_devices_multi_device_limit_reached_dialog_title">端末の数の制限に達しました</string>
+  <string name="activity_linked_devices_multi_device_limit_reached_dialog_explanation">現在、複数の端末をリンクすることはできません。</string>
+  <string name="activity_linked_devices_unlinking_failed_message">端末のリンクを解除できませんでした。</string>
+  <string name="activity_linked_devices_unlinking_successful_message">端末は正常にリンク解除されました</string>
+  <string name="activity_linked_devices_linking_failed_message">端末をリンクできませんでした。</string>
+  <string name="activity_linked_devices_empty_state_message">まだ端末をリンクしていません</string>
+  <string name="activity_linked_devices_empty_state_button_title">端末をリンクする（ベータ）</string>
 
   <string name="preferences_notifications_strategy_category_title">通知戦略</string>
 
   <string name="dialog_link_device_slave_mode_title_1">承認待ち</string>
-  <string name="dialog_link_device_slave_mode_title_2">承認されたデバイスリンク</string>
-  <string name="dialog_link_device_slave_mode_explanation_1">以下の単語が、他のデバイスに表示されている単語と一致することを確認してください。</string>
-  <string name="dialog_link_device_slave_mode_explanation_2">デバイスが正常にリンクされました</string>
+  <string name="dialog_link_device_slave_mode_title_2">承認された端末リンク</string>
+  <string name="dialog_link_device_slave_mode_explanation_1">以下の単語が、他の端末に表示されている単語と一致することを確認してください。</string>
+  <string name="dialog_link_device_slave_mode_explanation_2">端末が正常にリンクされました</string>
 
-  <string name="dialog_link_device_master_mode_title_1">デバイス待ち</string>
+  <string name="dialog_link_device_master_mode_title_1">端末待ち</string>
   <string name="dialog_link_device_master_mode_title_2">リンクリクエストを受け取りました</string>
-  <string name="dialog_link_device_master_mode_title_3">デバイスリンクの認証</string>
-  <string name="dialog_link_device_master_mode_explanation_1">他のデバイスでセッションをダウンロードし、ランディング画面の下部にある [既存のアカウントにリンク] をタップします。他のデバイスに既存のアカウントがある場合は、最初にそのアカウントを削除する必要があります。</string>
-  <string name="dialog_link_device_master_mode_explanation_2">以下の単語が、他のデバイスに表示されている単語と一致することを確認してください。</string>
-  <string name="dialog_link_device_master_mode_explanation_3">デバイスリンクが作成されるまでお待ちください。これには 1 分ほどかかる場合があります。</string>
+  <string name="dialog_link_device_master_mode_title_3">端末リンクの認証</string>
+  <string name="dialog_link_device_master_mode_explanation_1">他の端末でセッションをダウンロードし、ランディング画面の下部にある「既存のアカウントにリンク」をタップします。他の端末に既存のアカウントがある場合は、最初にそのアカウントを削除する必要があります。</string>
+  <string name="dialog_link_device_master_mode_explanation_2">以下の単語が、他の端末に表示されている単語と一致することを確認してください。</string>
+  <string name="dialog_link_device_master_mode_explanation_3">端末のリンクが作成されるまでお待ちください。これには 1 分ほどかかる場合があります。</string>
   <string name="dialog_link_device_master_mode_authorize_button_title">承認する</string>
 
   <string name="fragment_device_list_bottom_sheet_change_name_button_title">名前を変更する</string>
-  <string name="fragment_device_list_bottom_sheet_unlink_device_button_title">デバイスのリンクを解除する</string>
+  <string name="fragment_device_list_bottom_sheet_unlink_device_button_title">端末のリンクを解除する</string>
 
   <string name="dialog_edit_device_name_edit_text_hint">名前を入力する</string>
 
   <string name="dialog_seed_title">あなたのリカバリーフレーズ</string>
-  <string name="dialog_seed_explanation">これはあなたのリカバリーフレーズです。これにより、Session ID を新しいデバイスに復元または移行できます。</string>
+  <string name="dialog_seed_explanation">これはあなたのリカバリーフレーズです。これにより、Session ID を新しい端末に復元または移行できます。</string>
 
   <string name="dialog_clear_all_data_title">すべてのデータを消去する</string>
   <string name="dialog_clear_all_data_explanation">これにより、メッセージ、Session、連絡先が完全に削除されます。</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -493,7 +493,7 @@
   <string name="RegistrationActivity_i_understand">分かりました</string>
   <string name="RegistrationActivity_play_services_error">Google Play開発者サービスのエラー</string>
   <string name="RegistrationActivity_google_play_services_is_updating_or_unavailable">Google Play開発者サービスは更新中か一時的に使用不能です。再度試してください。</string>
-  <string name="RegistrationActivity_terms_and_privacy">使用条件とプライバシーポリシー</string>
+  <string name="RegistrationActivity_terms_and_privacy">利用規約とプライバシーポリシー</string>
   <string name="RegistrationActivity_no_browser">このリンクは開けません。ウェブブラウザが見つかりません。</string>
   <string name="RegistrationActivity_more_information">詳細</string>
   <string name="RegistrationActivity_less_information">詳細を隠す</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1349,24 +1349,24 @@
   <string name="fragment_scan_qr_code_camera_access_explanation">Session で QR コードをスキャンするにはカメラへのアクセスが必要です</string>
   <string name="fragment_scan_qr_code_grant_camera_access_button_title">カメラへのアクセスを許可する</string>
 
-  <string name="activity_create_closed_group_title">新しいクローズドグループ</string>
+  <string name="activity_create_closed_group_title">新しい非公開グループ</string>
   <string name="activity_create_closed_group_edit_text_hint">グループ名を入力してください</string>
-  <string name="activity_create_closed_group_explanation">クローズドグループは最大 10 人のメンバーをサポートし、1 対 1 の Session と同じプライバシー保護を提供します。</string>
+  <string name="activity_create_closed_group_explanation">非公開グループは最大 10 人のメンバーをサポートし、1 対 1 の Session と同じプライバシー保護を提供します。</string>
   <string name="activity_create_closed_group_empty_state_message">まだ連絡先がありません</string>
   <string name="activity_create_closed_group_empty_state_button_title">Session を開始する</string>
   <string name="activity_create_closed_group_group_name_missing_error">グループ名を入力してください</string>
   <string name="activity_create_closed_group_group_name_too_long_error">短いグループ名を入力してください</string>
   <string name="activity_create_closed_group_not_enough_group_members_error">グループメンバーを少なくとも 2 人選択してください</string>
-  <string name="activity_create_closed_group_too_many_group_members_error">閉じたグループは 100 人を超えるメンバーを抱えることはできません</string>
+  <string name="activity_create_closed_group_too_many_group_members_error">非公開グループは 100 人を超えるメンバーを抱えることはできません</string>
   <string name="activity_create_closed_group_invalid_session_id_error">グループのメンバーの 1 人の Session ID が無効です</string>
 
-  <string name="activity_join_public_chat_title">オープングループに参加する</string>
+  <string name="activity_join_public_chat_title">公開グループに参加する</string>
   <string name="activity_join_public_chat_error">グループに参加できませんでした</string>
   <string name="activity_join_public_chat_enter_group_url_tab_title">グループの URL を開く</string>
   <string name="activity_join_public_chat_scan_qr_code_tab_title">QR コードをスキャンする</string>
-  <string name="activity_join_public_chat_scan_qr_code_explanation">参加したいオープングループの QR コードをスキャンする</string>
+  <string name="activity_join_public_chat_scan_qr_code_explanation">参加したい公開グループの QR コードをスキャンする</string>
 
-  <string name="fragment_enter_chat_url_edit_text_hint">オープングループの URL を入力する</string>
+  <string name="fragment_enter_chat_url_edit_text_hint">公開グループの URL を入力する</string>
 
   <string name="activity_settings_title">設定</string>
   <string name="activity_settings_display_name_edit_text_hint">表示名を入力してください</string>
@@ -1436,7 +1436,7 @@
   <string name="session_reset_banner_restore_button_title">戻す</string>
 
   <string name="fragment_contact_selection_contacts_title">連絡先</string>
-  <string name="fragment_contact_selection_closed_groups_title">閉じたグループ</string>
-  <string name="fragment_contact_selection_open_groups_title">オープングループ</string>
+  <string name="fragment_contact_selection_closed_groups_title">非公開グループ</string>
+  <string name="fragment_contact_selection_open_groups_title">公開グループ</string>
 
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -390,7 +390,7 @@
   <!--MediaRepository-->
   <string name="MediaRepository_all_media">すべてのメディア</string>
   <!--MessageRecord-->
-  <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">受信したメッセージは古いSessionで暗号化されているので解読不能です。Sessionを更新して再送するよう送信者にお願いしてください。</string>
+  <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">受信したメッセージは古いSessionで暗号化されているので解読不能です。Sessionを更新して再送するよう送信者に頼んでください。</string>
   <string name="MessageRecord_left_group">グループを抜けました</string>
   <string name="MessageRecord_you_updated_group">グループを更新しました</string>
   <string name="MessageRecord_you_called">発信</string>
@@ -572,7 +572,7 @@
   <string name="UnverifiedSendDialog_send_message">送信しますか？</string>
   <string name="UnverifiedSendDialog_send">送信</string>
   <!--VerifyIdentityActivity-->
-  <string name="VerifyIdentityActivity_your_contact_is_running_an_old_version_of_signal">連絡先の相手は古いSessionを使っています。Sessionを更新してから安全番号の検証を行うようお願いしてください。</string>
+  <string name="VerifyIdentityActivity_your_contact_is_running_an_old_version_of_signal">連絡先の相手は古いSessionを使っています。Sessionを更新してから安全番号の検証を行うよう頼んでください。</string>
   <string name="VerifyIdentityActivity_your_contact_is_running_a_newer_version_of_Signal">相手がより新しいバージョンのSessionを使っているため，QRコードの形式が異なります。Sessionを更新してから改めて比較してください。</string>
   <string name="VerifyIdentityActivity_the_scanned_qr_code_is_not_a_correctly_formatted_safety_number">読み取ったQRコードは、適正な安全番号認証コードではありません。もう一度読み取って下さい。</string>
   <string name="VerifyIdentityActivity_share_safety_number_via">次の方法で安全番号を共有...</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1407,7 +1407,7 @@
   <string name="dialog_link_device_master_mode_title_1">端末待ち</string>
   <string name="dialog_link_device_master_mode_title_2">リンクリクエストを受け取りました</string>
   <string name="dialog_link_device_master_mode_title_3">端末リンクの認証</string>
-  <string name="dialog_link_device_master_mode_explanation_1">他の端末でセッションをダウンロードし、ランディング画面の下部にある「既存のアカウントにリンク」をタップします。他の端末に既存のアカウントがある場合は、最初にそのアカウントを削除する必要があります。</string>
+  <string name="dialog_link_device_master_mode_explanation_1">他の端末でSessionをダウンロードし、ランディング画面の下部にある「既存のアカウントにリンク」をタップします。他の端末に既存のアカウントがある場合は、最初にそのアカウントを削除する必要があります。</string>
   <string name="dialog_link_device_master_mode_explanation_2">以下の単語が、他の端末に表示されている単語と一致することを確認してください。</string>
   <string name="dialog_link_device_master_mode_explanation_3">端末のリンクが作成されるまでお待ちください。これには 1 分ほどかかる場合があります。</string>
   <string name="dialog_link_device_master_mode_authorize_button_title">承認する</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1308,7 +1308,7 @@
   <string name="activity_display_name_explanation">これは、Session を使用するときの名前になります。あなたの本当の名前、エイリアス、またはあなたが好きな他のものに設定することができます。</string>
   <string name="activity_display_name_edit_text_hint">表示名を入力してください</string>
   <string name="activity_display_name_display_name_missing_error">表示名を選択してください</string>
-  <string name="activity_display_name_display_name_invalid_error">AZ、AZ、0-9、_ の文字のみで構成される表示名を選択してください</string>
+  <string name="activity_display_name_display_name_invalid_error">a-z、A-Z、0-9、_ の文字のみで構成される表示名を選択してください</string>
   <string name="activity_display_name_display_name_too_long_error">短い表示名を選択してください</string>
 
   <string name="activity_pn_mode_recommended_option_tag">オススメ</string>
@@ -1371,7 +1371,7 @@
   <string name="activity_settings_title">設定</string>
   <string name="activity_settings_display_name_edit_text_hint">表示名を入力してください</string>
   <string name="activity_settings_display_name_missing_error">表示名を選択してください</string>
-  <string name="activity_settings_invalid_display_name_error">AZ、AZ、0-9、_ の文字のみで構成される表示名を選択してください</string>
+  <string name="activity_settings_invalid_display_name_error">a-z、A-Z、0-9、_ の文字のみで構成される表示名を選択してください</string>
   <string name="activity_settings_display_name_too_long_error">短い表示名を選択してください</string>
   <string name="activity_settings_privacy_button_title">プライバシー</string>
   <string name="activity_settings_notifications_button_title">お知らせ</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -97,7 +97,7 @@
   <string name="ContactShareEditActivity_type_mobile">携帯</string>
   <string name="ContactShareEditActivity_type_work">職場</string>
   <string name="ContactShareEditActivity_type_missing">その他</string>
-  <string name="ContactShareEditActivity_invalid_contact">選択された連絡先は無効です</string>
+  <string name="ContactShareEditActivity_invalid_contact">選択された連絡先は不正です</string>
   <!--ConversationItem-->
   <string name="ConversationItem_error_not_delivered">送信失敗、タップして詳細を見る</string>
   <string name="ConversationItem_received_key_exchange_message_tap_to_process">鍵交換のメッセージを受信しました。タップして手続きを行ってください。</string>
@@ -124,7 +124,7 @@
   <string name="ConversationActivity_recipient_is_not_a_valid_sms_or_email_address_exclamation">受信先のSMS又はEメールアドレスが有効ではありません。</string>
   <string name="ConversationActivity_message_is_empty_exclamation">メッセージが空です。</string>
   <string name="ConversationActivity_group_members">グループメンバー</string>
-  <string name="ConversationActivity_invalid_recipient">受信先が無効です。</string>
+  <string name="ConversationActivity_invalid_recipient">受信先が不正です。</string>
   <string name="ConversationActivity_added_to_home_screen">ホーム画面に追加しました</string>
   <string name="ConversationActivity_calls_not_supported">通話には対応していません</string>
   <string name="ConversationActivity_this_device_does_not_appear_to_support_dial_actions">お使いの端末は、ダイヤル機能に対応していないようです。</string>
@@ -442,7 +442,7 @@
   <string name="PassphrasePromptActivity_enter_passphrase">パスフレーズを入力してください</string>
   <string name="PassphrasePromptActivity_watermark_content_description">Sessionアイコン</string>
   <string name="PassphrasePromptActivity_ok_button_content_description">パスフレーズを設定</string>
-  <string name="PassphrasePromptActivity_invalid_passphrase_exclamation">無効なパスフレーズです！</string>
+  <string name="PassphrasePromptActivity_invalid_passphrase_exclamation">不正なパスフレーズです！</string>
   <!--PlayServicesProblemFragment-->
   <string name="PlayServicesProblemFragment_the_version_of_google_play_services_you_have_installed_is_not_functioning">インストールされているGoogle Play開発者サービスのバージョンは正しく動作していません。Google Play開発者サービスを再インストールして再挑戦してみてください。</string>
   <!--RatingManager-->
@@ -486,7 +486,7 @@
   <string name="RegistrationActivity_select_your_country">国を選択</string>
   <string name="RegistrationActivity_you_must_specify_your_country_code">国番号を入力して下さい</string>
   <string name="RegistrationActivity_you_must_specify_your_phone_number">電話番号を入力して下さい</string>
-  <string name="RegistrationActivity_invalid_number">無効な番号</string>
+  <string name="RegistrationActivity_invalid_number">不正な番号</string>
   <string name="RegistrationActivity_the_number_you_specified_s_is_invalid">指定された番号(%s)はお使いできません。</string>
   <string name="RegistrationActivity_missing_google_play_services">Google Play開発者サービスがありません</string>
   <string name="RegistrationActivity_this_device_is_missing_google_play_services">この端末にはGoogle Play開発者サービスがありません。Sessionは使用できますが、信頼性や性能は下がる可能性があります。\n\n上級者でない方や、メーカー公式のAndroidをご利用の方、何かの間違いだと思う方などは support@signal.org まで連絡してください。</string>
@@ -533,8 +533,8 @@
   <string name="Slide_audio">音声</string>
   <string name="Slide_video">動画</string>
   <!--SmsMessageRecord-->
-  <string name="SmsMessageRecord_received_corrupted_key_exchange_message">無効な鍵交換メッセージを受信しました</string>
-  <string name="SmsMessageRecord_received_key_exchange_message_for_invalid_protocol_version">受信した鍵交換メッセージのプロトコルバージョンが無効です</string>
+  <string name="SmsMessageRecord_received_corrupted_key_exchange_message">不正な鍵交換メッセージを受信しました</string>
+  <string name="SmsMessageRecord_received_key_exchange_message_for_invalid_protocol_version">受信した鍵交換メッセージのプロトコルバージョンが不正です</string>
   <string name="SmsMessageRecord_received_message_with_new_safety_number_tap_to_process">新しい安全番号が付いたメッセージを受け取りました。処理や表示を行うにはタップしてください。</string>
   <string name="SmsMessageRecord_secure_session_reset">セキュアセッションを設定し直しました</string>
   <string name="SmsMessageRecord_secure_session_reset_s">%sがセキュアセッションを設定し直しました。</string>
@@ -1266,12 +1266,12 @@
   <!-- Session -->
   <string name="continue_2">続行する</string>
   <string name="copy">コピーする</string>
-  <string name="invalid_url">URL が無効です</string>
+  <string name="invalid_url">URL が不正です</string>
   <string name="copied_to_clipboard">クリップボードにコピーされました</string>
   <string name="device_linking_failed">端末をリンクできませんでした。</string>
   <string name="next">次</string>
   <string name="share">共有する</string>
-  <string name="invalid_session_id">Session ID が無効です</string>
+  <string name="invalid_session_id">Session ID が不正です</string>
   <string name="cancel">取り消す</string>
   <string name="your_session_id">あなたの Session ID</string>
 
@@ -1358,7 +1358,7 @@
   <string name="activity_create_closed_group_group_name_too_long_error">短いグループ名を入力してください</string>
   <string name="activity_create_closed_group_not_enough_group_members_error">グループメンバーを少なくとも 2 人選択してください</string>
   <string name="activity_create_closed_group_too_many_group_members_error">非公開グループは 100 人を超えるメンバーを抱えることはできません</string>
-  <string name="activity_create_closed_group_invalid_session_id_error">グループのメンバーの 1 人の Session ID が無効です</string>
+  <string name="activity_create_closed_group_invalid_session_id_error">グループのメンバーの 1 人の Session ID が不正です</string>
 
   <string name="activity_join_public_chat_title">公開グループに参加する</string>
   <string name="activity_join_public_chat_error">グループに参加できませんでした</string>


### PR DESCRIPTION
This is my first pull request and my first set of contributions to Japanese translation.

My aims:

- Improve comprehensibility and correctness of Japanese translations.
- Make Japanese translations consistent within and across Session repos.

I wanted to start with baby steps. I can create pull requests for session-desktop and session-ios, for which I have already made similar commits. I can also translate the new strings and then create new pull requests.

Please refer to each commit message for details.

These commits are ready to be merged in as is, but I suggest another person who is fluent in Japanese review these commits. For example, maybe the person who started issue https://github.com/oxen-io/session-desktop/issues/1497 is able and willing to review?

Comments are most welcome.