### PR TITLE
Fix repo documentation

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -21,15 +21,6 @@ Ensure that the following packages are installed from the Android SDK manager:
 
 In Android studio, this can be done from the Quickstart panel, choose "Configure" then "SDK Manager". In the SDK Tools tab of the SDK Manager, make sure that the "Android Support Repository" is installed, and that the latest "Android SDK build-tools" are installed. Click "OK" to return to the Quickstart panel. You may also need to install API version 28 in the SDK platforms tab.
 
-You will then need to clone and run `./gradlew install` on each of the following repositories IN ORDER:
-
-* https://github.com/loki-project/loki-messenger-android-curve-25519
-* https://github.com/loki-project/loki-messenger-android-protocol
-* https://github.com/loki-project/loki-messenger-android-meta
-* https://github.com/loki-project/session-android-service
-
-This installs these dependencies into a local Maven repository which the main Session Android repository will then draw from.
-
 Setting up a development environment and building from Android Studio
 ------------------------------------
 
@@ -37,7 +28,7 @@ Setting up a development environment and building from Android Studio
 
 1. Open Android Studio. On a new installation, the Quickstart panel will appear. If you have open projects, close them using "File > Close Project" to see the Quickstart panel.
 2. From the Quickstart panel, choose "Checkout from Version Control" then "git".
-3. Paste the URL for the session-android project when prompted (https://github.com/loki-project/session-android.git).
+3. Paste the URL for the session-android project when prompted (https://github.com/oxen-io/session-android.git).
 4. Android Studio should detect the presence of a project file and ask you whether to open it. Click "yes".
 5. Default config options should be good enough.
 6. Project initialization and building should proceed.
@@ -49,7 +40,7 @@ The following steps should help you (re)build Session from the command line once
 
 1. Checkout the session-android project source with the command:
 
-        git clone https://github.com/loki-project/session-android.git
+        git clone https://github.com/oxen-io/session-android.git
 
 2. Make sure you have the [Android SDK](https://developer.android.com/sdk/index.html) installed.
 3. Create a local.properties file at the root of your source checkout and add an sdk.dir entry to it. For example:
@@ -58,7 +49,7 @@ The following steps should help you (re)build Session from the command line once
 
 4. Execute Gradle:
 
-        ./gradlew build
+        ./gradlew :app:build
 
 Contributing code
 -----------------

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Download on the Google Play Store](https://getsession.org/android)
 
-[Download via F-Droid](https://fdroid.getsession.org/fdroid/repo?fingerprint=DB0E5297EB65CC22D6BD93C869943BDCFCB6A07DC69A48A0DD8C7BA698EC04E6)
+Add the [F-Droid repo](https://fdroid.getsession.org/)
 
 [Grab the APK here](https://github.com/loki-project/session-android/releases/latest)
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,19 @@
 
 [Download on the Google Play Store](https://getsession.org/android)
 
+[Download via F-Droid](https://fdroid.getsession.org/fdroid/repo?fingerprint=DB0E5297EB65CC22D6BD93C869943BDCFCB6A07DC69A48A0DD8C7BA698EC04E6)
+
 [Grab the APK here](https://github.com/loki-project/session-android/releases/latest)
 
 ## Summary
 
-Session integrates directly with [Loki Service Nodes](https://lokidocs.com/ServiceNodes/SNOverview/), which are a set of distributed, decentralized and Sybil resistant nodes. Service Nodes act as servers which store messages offline, and a set of nodes which allow for onion routing functionality obfuscating users' IP addresses. For a full understanding of how Session works, read the [Session Whitepaper](https://getsession.org/whitepaper).
+Session integrates directly with [Oxen Service Nodes](https://docs.oxen.io/about-the-oxen-blockchain/oxen-service-nodes), which are a set of distributed, decentralized and Sybil resistant nodes. Service Nodes act as servers which store messages offline, and a set of nodes which allow for onion routing functionality obfuscating users' IP addresses. For a full understanding of how Session works, read the [Session Whitepaper](https://getsession.org/whitepaper).
 
 ![AndroidSession](https://i.imgur.com/0YC9TyI.png)
 
 ## Want to contribute? Found a bug or have a feature request?
 
-Please search for any [existing issues](https://github.com/loki-project/session-android/issues) that describe your bugs in order to avoid duplicate submissions. Submissions can be made by making a pull request to our development branch. If you don't know where to start contributing, try reading the Github issues page for ideas.
+Please search for any [existing issues](https://github.com/oxen-io/session-android/issues) that describe your bugs in order to avoid duplicate submissions. Submissions can be made by making a pull request to our `dev` branch. If you don't know where to start contributing, try reading the Github issues page for ideas.
 
 ## Build instructions
 


### PR DESCRIPTION
remove old build instructions and replace links from loki-project to oxen-io, as well as link to oxen docs on service nodes