### PR TITLE
Fix Formation Timestamp Handling for Users Re-Joining a Closed Group

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/GroupDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/GroupDatabase.java
@@ -308,6 +308,13 @@ public class GroupDatabase extends Database implements LokiOpenGroupDatabaseProt
     databaseHelper.getWritableDatabase().update(TABLE_NAME, contents, GROUP_ID + " = ?", new String[] {groupId});
   }
 
+  public void updateFormationTimestamp(String groupId, Long formationTimestamp) {
+    ContentValues contents = new ContentValues();
+    contents.put(TIMESTAMP, formationTimestamp);
+
+    databaseHelper.getWritableDatabase().update(TABLE_NAME, contents, GROUP_ID + " = ?", new String[] {groupId});
+  }
+
   public void removeMember(String groupId, Address source) {
     List<Address> currentMembers = getCurrentMembers(groupId, false);
     currentMembers.remove(source);

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -428,6 +428,10 @@ class Storage(context: Context, helper: SQLCipherOpenHelper) : Database(context,
         DatabaseFactory.getLokiAPIDatabase(context).removeAllClosedGroupEncryptionKeyPairs(groupPublicKey)
     }
 
+    override fun updateFormationTimestamp(groupID: String, formationTimestamp: Long) {
+        DatabaseFactory.getGroupDatabase(context).updateFormationTimestamp(groupID, formationTimestamp)
+    }
+
     override fun getAllV2OpenGroups(): Map<Long, OpenGroupV2> {
         return DatabaseFactory.getLokiThreadDatabase(context).getAllV2OpenGroups()
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/loki/activities/EditClosedGroupMembersAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/loki/activities/EditClosedGroupMembersAdapter.kt
@@ -56,6 +56,8 @@ class EditClosedGroupMembersAdapter(
 
         if (unlocked) {
             viewHolder.view.setOnClickListener { this.memberClickListener?.invoke(member) }
+        } else {
+            viewHolder.view.setOnClickListener(null)
         }
     }
 

--- a/libsession/src/main/java/org/session/libsession/database/StorageProtocol.kt
+++ b/libsession/src/main/java/org/session/libsession/database/StorageProtocol.kt
@@ -115,6 +115,7 @@ interface StorageProtocol {
     fun isClosedGroup(publicKey: String): Boolean
     fun getClosedGroupEncryptionKeyPairs(groupPublicKey: String): MutableList<ECKeyPair>
     fun getLatestClosedGroupEncryptionKeyPair(groupPublicKey: String): ECKeyPair?
+    fun updateFormationTimestamp(groupID: String, formationTimestamp: Long)
 
     // Groups
     fun getAllGroups(): List<GroupRecord>

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSenderClosedGroupHandler.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSenderClosedGroupHandler.kt
@@ -161,7 +161,7 @@ fun MessageSender.addMembers(groupPublicKey: String, membersToAdd: List<String>)
     for (member in membersToAdd) {
         val closedGroupNewKind = ClosedGroupControlMessage.Kind.New(ByteString.copyFrom(Hex.fromStringCondensed(groupPublicKey)), name, encryptionKeyPair, membersAsData, adminsAsData, expireTimer)
         val closedGroupControlMessage = ClosedGroupControlMessage(closedGroupNewKind)
-        closedGroupControlMessage.sentTimestamp = sentTime
+        closedGroupControlMessage.sentTimestamp = System.currentTimeMillis()
         send(closedGroupControlMessage, Address.fromSerialized(member))
     }
     // Notify the user

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/ReceivedMessageHandler.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/ReceivedMessageHandler.kt
@@ -429,7 +429,7 @@ private fun MessageReceiver.handleClosedGroupMembersAdded(message: ClosedGroupCo
         val encryptionKeyPair = pendingKeyPairs[groupPublicKey]?.orNull()
             ?: storage.getLatestClosedGroupEncryptionKeyPair(groupPublicKey)
         if (encryptionKeyPair == null) {
-            android.util.Log.d("Loki", "Couldn't get encryption key pair for closed group.")
+            Log.d("Loki", "Couldn't get encryption key pair for closed group.")
         } else {
             for (user in updateMembers) {
                 MessageSender.sendEncryptionKeyPair(groupPublicKey, encryptionKeyPair, setOf(user), targetUser = user, force = false)
@@ -561,12 +561,12 @@ private fun isValidGroupUpdate(group: GroupRecord, sentTimestamp: Long, senderPu
     val oldMembers = group.members.map { it.serialize() }
     // Check that the message isn't from before the group was created
     if (group.formationTimestamp > sentTimestamp) {
-        android.util.Log.d("Loki", "Ignoring closed group update from before thread was created.")
+        Log.d("Loki", "Ignoring closed group update from before thread was created.")
         return false
     }
     // Check that the sender is a member of the group (before the update)
     if (senderPublicKey !in oldMembers) {
-        android.util.Log.d("Loki", "Ignoring closed group info message from non-member.")
+        Log.d("Loki", "Ignoring closed group info message from non-member.")
         return false
     }
     return true


### PR DESCRIPTION
When a member is re-added to a group, formationTimestamp value of the group is updated in order to ignore all group updates that happened when the member wasn't in the group.

+ Fix for a couple of minor issues