### PR TITLE
Display the service node's IP address after its country.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/IP2Country.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/IP2Country.kt
@@ -99,7 +99,7 @@ class IP2Country private constructor(private val context: Context) {
 
         val bestMatchCountry = comps.lastOrNull { it.key <= Ipv4Int(ip)  }?.let { (_, code) ->
             if (code != null) {
-                countryToNames[code]
+                countryToNames[code] + " [" + ip + "]"
             } else {
                 null
             }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy Note20 Ultra (SM-T986B) Android 11
 * Virtual device: Pixel 4 XL API 30
- [x] My contribution is fully baked and ready to be merged as is

----------

### Description

This change adds each service node's IP address to the onion path window. I personally find this information useful to check the networks of the nodes I am being routed through, and I think other users will enjoy having the extra information, too.

I have tested that the change works as described in the Android emulator and on a real device.