### PR TITLE
Fix open group requests

### DIFF
--- a/libsession/src/main/java/org/session/libsession/messaging/open_groups/OpenGroupAPIV2.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/open_groups/OpenGroupAPIV2.kt
@@ -214,7 +214,7 @@ object OpenGroupAPIV2 {
         val parameters = mapOf( "file" to base64EncodedFile )
         val request = Request(verb = POST, room = room, server = server, endpoint = "files", parameters = parameters)
         return send(request).map { json ->
-            json["result"] as? Long ?: throw Error.ParsingFailed
+            (json["result"] as? Number)?.toLong() ?: throw Error.ParsingFailed
         }
     }
 


### PR DESCRIPTION
Integer responses automatically interpreted as Map<*,*> were failing to parse as Long properly, use `Number.toLong()` to prevent in future