### PR TITLE
Make the unread message count 4 digits instead of 2.

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -756,9 +756,9 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
     }
 
     private fun updateUnreadCountIndicator() {
-        val formattedUnreadCount = if (unreadCount < 100) unreadCount.toString() else "99+"
+        val formattedUnreadCount = if (unreadCount < 10000) unreadCount.toString() else "9999+"
         binding.unreadCountTextView.text = formattedUnreadCount
-        val textSize = if (unreadCount < 100) 12.0f else 9.0f
+        val textSize = if (unreadCount < 10000) 12.0f else 9.0f
         binding.unreadCountTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, textSize)
         binding.unreadCountTextView.setTypeface(Typeface.DEFAULT, if (unreadCount < 100) Typeface.BOLD else Typeface.NORMAL)
         binding.unreadCountIndicator.isVisible = (unreadCount != 0)

--- a/app/src/main/java/org/thoughtcrime/securesms/home/ConversationView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/ConversationView.kt
@@ -61,10 +61,10 @@ class ConversationView : LinearLayout {
         val formattedUnreadCount = if (thread.isRead) {
             null
         } else {
-            if (unreadCount < 100) unreadCount.toString() else "99+"
+            if (unreadCount < 10000) unreadCount.toString() else "9999+"
         }
         binding.unreadCountTextView.text = formattedUnreadCount
-        val textSize = if (unreadCount < 100) 12.0f else 9.0f
+        val textSize = if (unreadCount < 10000) 12.0f else 9.0f
         binding.unreadCountTextView.setTextSize(TypedValue.COMPLEX_UNIT_DIP, textSize)
         binding.unreadCountTextView.setTypeface(Typeface.DEFAULT, if (unreadCount < 100) Typeface.BOLD else Typeface.NORMAL)
         binding.unreadCountIndicator.isVisible = (unreadCount != 0 && !thread.isRead)

--- a/app/src/main/res/layout/activity_conversation_v2.xml
+++ b/app/src/main/res/layout/activity_conversation_v2.xml
@@ -115,7 +115,7 @@
 
         <RelativeLayout
             android:id="@+id/unreadCountIndicator"
-            android:layout_width="20dp"
+            android:layout_width="40dp"
             android:layout_height="20dp"
             android:layout_centerHorizontal="true"
             android:layout_alignParentTop="true"

--- a/app/src/main/res/layout/view_conversation.xml
+++ b/app/src/main/res/layout/view_conversation.xml
@@ -63,7 +63,7 @@
 
                     <RelativeLayout
                         android:id="@+id/unreadCountIndicator"
-                        android:layout_width="20dp"
+                        android:layout_width="40dp"
                         android:layout_height="20dp"
                         android:layout_marginStart="4dp"
                         android:background="@drawable/circle_tintable"


### PR DESCRIPTION
99+ unread messages can be reached within an hour in some busy open
groups. 4 digits allow for much more accurate reporting.

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have tested my contribution on these devices:
 * Virtual device Pixel 4 XL, API 30 on emulator
- [x] My contribution is fully baked and ready to be merged as is

----------

### Description

This fixes the low-granularity reporting of the unread message count, mentioned in #826, but does not address the main issue.

<img width="487" alt="image" src="https://user-images.githubusercontent.com/749942/149755127-a9b41a9d-8b93-4e35-9ab2-4ffa1b8a8dea.png">
