### PR TITLE
Use accent colour for unread count indicator background in dark mode.

### DIFF
--- a/app/src/main/res/layout/activity_conversation_v2.xml
+++ b/app/src/main/res/layout/activity_conversation_v2.xml
@@ -131,7 +131,7 @@
                 android:layout_height="wrap_content"
                 android:layout_centerInParent="true"
                 android:textSize="@dimen/very_small_font_size"
-                android:textColor="@color/text"
+                android:textColor="@color/conversation_unread_count_indicator_text"
                 android:text="8" />
 
         </RelativeLayout>

--- a/app/src/main/res/layout/view_conversation.xml
+++ b/app/src/main/res/layout/view_conversation.xml
@@ -78,7 +78,7 @@
                             android:layout_height="wrap_content"
                             android:layout_centerInParent="true"
                             android:text="8"
-                            android:textColor="@color/text"
+                            android:textColor="@color/conversation_unread_count_indicator_text"
                             android:textSize="@dimen/very_small_font_size"
                             android:textStyle="bold" />
 

--- a/app/src/main/res/layout/view_global_search_result.xml
+++ b/app/src/main/res/layout/view_global_search_result.xml
@@ -79,7 +79,7 @@
                     android:layout_height="wrap_content"
                     android:layout_centerInParent="true"
                     tools:text="8"
-                    android:textColor="@color/text"
+                    android:textColor="@color/conversation_unread_count_indicator_text"
                     android:textSize="@dimen/very_small_font_size"
                     android:textStyle="bold" />
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -36,7 +36,8 @@
     <color name="link_preview_background">#000000</color>
     <color name="scroll_to_bottom_button_background">#171717</color>
     <color name="scroll_to_bottom_button_border">#99FFFFFF</color>
-    <color name="conversation_unread_count_indicator_background">#303030</color>
+    <color name="conversation_unread_count_indicator_background">#00F782</color>
+    <color name="conversation_unread_count_indicator_text">#000000</color>
     <color name="conversation_pinned_background">#404040</color>
     <color name="conversation_pinned_icon">#B3B3B3</color>
 


### PR DESCRIPTION
The previous colour was too dark to emphasise conversations with unread messages.
    
To keep the count itself legible, the text has been switched to black.

### Contributor checklist
- [x] I have tested my contribution on these devices:
 * Pixel 4 XL API 30 (emulated)
- [x] My contribution is fully baked and ready to be merged as is

This fixes #844

----------

### Description

The background of the unread message counter is so dark in dark mode that conversations with unread messages don't stand out from those that are completely up to date.

This patch uses the accent colour instead, a choice I made because the same colour is used to highlight conversations with mentions. The text of the indicator itself is changed to black to keep it legible.

<img width="310" alt="image" src="https://user-images.githubusercontent.com/749942/153259514-b3c0cfd5-8335-4366-aa4a-68e2078e8190.png">

A similar change has been submitted to the desktop client:

https://github.com/oxen-io/session-desktop/pull/2167