### PR TITLE
Use current time + offset in snode message timestamps

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -159,7 +159,7 @@ dependencies {
     testImplementation 'org.robolectric:shadows-multidex:4.4'
 }
 
-def canonicalVersionCode = 283
+def canonicalVersionCode = 284
 def canonicalVersionName = "1.13.4"
 
 def postFixSize = 10

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -159,8 +159,8 @@ dependencies {
     testImplementation 'org.robolectric:shadows-multidex:4.4'
 }
 
-def canonicalVersionCode = 284
-def canonicalVersionName = "1.13.4"
+def canonicalVersionCode = 285
+def canonicalVersionName = "1.13.5"
 
 def postFixSize = 10
 def abiPostFix = ['armeabi-v7a' : 1,


### PR DESCRIPTION
Use current time in message sender's snode message timestamps to prevent 406 from repeat failed message sends