### PR TITLE
Fix thread notification processing to happen after thread unread and snippet updated

### DIFF
--- a/libsession/src/main/java/org/session/libsession/messaging/jobs/BatchMessageReceiveJob.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/jobs/BatchMessageReceiveJob.kt
@@ -133,9 +133,9 @@ class BatchMessageReceiveJob(
                             trueUnreadCount -= (unreadFromMine + 1)
                             storage.markConversationAsRead(threadId, false)
                         }
-                        SSKEnvironment.shared.notificationManager.updateNotification(context, threadId)
                         storage.incrementUnread(threadId, trueUnreadCount)
                         storage.updateThread(threadId, true)
+                        SSKEnvironment.shared.notificationManager.updateNotification(context, threadId)
                     }
                 }
 


### PR DESCRIPTION
fix: re-order when notification updates occur in batch message receive job