### PR TITLE
Fix voice message duration view

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VoiceMessageView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VoiceMessageView.kt
@@ -78,7 +78,7 @@ class VoiceMessageView : RelativeLayout, AudioSlidePlayer.Listener {
                     binding.voiceMessageViewDurationTextView.visibility = View.VISIBLE
                     binding.voiceMessageViewDurationTextView.text = String.format("%01d:%02d",
                             TimeUnit.MILLISECONDS.toMinutes(audioExtras.durationMs),
-                            TimeUnit.MILLISECONDS.toSeconds(audioExtras.durationMs))
+                            TimeUnit.MILLISECONDS.toSeconds(audioExtras.durationMs) % 60)
                 }
             }
         }
@@ -102,7 +102,7 @@ class VoiceMessageView : RelativeLayout, AudioSlidePlayer.Listener {
         this.progress = progress
         binding.voiceMessageViewDurationTextView.text = String.format("%01d:%02d",
             TimeUnit.MILLISECONDS.toMinutes(duration - (progress * duration.toDouble()).roundToLong()),
-            TimeUnit.MILLISECONDS.toSeconds(duration - (progress * duration.toDouble()).roundToLong()))
+            TimeUnit.MILLISECONDS.toSeconds(duration - (progress * duration.toDouble()).roundToLong()) % 60)
         val layoutParams = binding.progressView.layoutParams as RelativeLayout.LayoutParams
         layoutParams.width = (width.toFloat() * progress.toFloat()).roundToInt()
         binding.progressView.layoutParams = layoutParams


### PR DESCRIPTION
The seconds for a voice message duration, and also its decreasing duration when played, were just the total duration of the audio. So, a 3 minute audio would appear as 3:180 at the audio's right, and 2:170 for example when said audio is being played.

I added a modulo operator for 60 after the time millisecond to seconds conversion, just before setting it as viewable text, same for the progress function.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
