### PR TITLE
Fix improperly caching `notifyType` on `Recipient`s

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/GroupMemberDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/GroupMemberDatabase.kt
@@ -3,9 +3,9 @@ package org.thoughtcrime.securesms.database
 import android.content.ContentValues
 import android.content.Context
 import android.database.Cursor
-import org.thoughtcrime.securesms.database.helpers.SQLCipherOpenHelper
 import org.session.libsession.messaging.open_groups.GroupMember
 import org.session.libsession.messaging.open_groups.GroupMemberRole
+import org.thoughtcrime.securesms.database.helpers.SQLCipherOpenHelper
 
 class GroupMemberDatabase(context: Context, helper: SQLCipherOpenHelper) : Database(context, helper) {
 
@@ -63,6 +63,18 @@ class GroupMemberDatabase(context: Context, helper: SQLCipherOpenHelper) : Datab
             val args = arrayOf(member.groupId, member.profileId)
 
             writableDatabase.insertOrUpdate(TABLE_NAME, values, query, args)
+            writableDatabase.setTransactionSuccessful()
+        } finally {
+            writableDatabase.endTransaction()
+        }
+    }
+
+    fun clearGroupMemberRoles(groupId: String) {
+        writableDatabase.beginTransaction()
+        try {
+            val query = "$GROUP_ID = ?"
+            val args = arrayOf(groupId)
+            writableDatabase.delete(TABLE_NAME, query, args)
             writableDatabase.setTransactionSuccessful()
         } finally {
             writableDatabase.endTransaction()

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -324,7 +324,11 @@ class Storage(context: Context, helper: SQLCipherOpenHelper) : Database(context,
         return getAllOpenGroups().values.firstOrNull { it.server == server && it.room == room }
     }
 
-    override fun addGroupMember(member: GroupMember) {
+    override fun clearGroupMemberRoles(groupId: String) {
+        DatabaseComponent.get(context).groupMemberDatabase().clearGroupMemberRoles(groupId)
+    }
+
+    override fun addGroupMemberRole(member: GroupMember) {
         DatabaseComponent.get(context).groupMemberDatabase().addGroupMember(member)
     }
 

--- a/libsession/src/main/java/org/session/libsession/database/StorageProtocol.kt
+++ b/libsession/src/main/java/org/session/libsession/database/StorageProtocol.kt
@@ -71,7 +71,8 @@ interface StorageProtocol {
     fun hasBackgroundGroupAddJob(groupJoinUrl: String): Boolean
     fun setOpenGroupServerMessageID(messageID: Long, serverID: Long, threadID: Long, isSms: Boolean)
     fun getOpenGroup(room: String, server: String): OpenGroup?
-    fun addGroupMember(member: GroupMember)
+    fun addGroupMemberRole(member: GroupMember)
+    fun clearGroupMemberRoles(groupId: String)
 
     // Open Group Public Keys
     fun getOpenGroupPublicKey(server: String): String?

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPoller.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/OpenGroupPoller.kt
@@ -134,18 +134,20 @@ class OpenGroupPoller(private val server: String, private val executorService: S
         storage.setUserCount(roomToken, server, pollInfo.activeUsers)
 
         // - Moderators
+        storage.clearGroupMemberRoles(groupId)
+
         pollInfo.details?.moderators?.forEach {
-            storage.addGroupMember(GroupMember(groupId, it, GroupMemberRole.MODERATOR))
+            storage.addGroupMemberRole(GroupMember(groupId, it, GroupMemberRole.MODERATOR))
         }
         pollInfo.details?.hiddenModerators?.forEach {
-            storage.addGroupMember(GroupMember(groupId, it, GroupMemberRole.HIDDEN_MODERATOR))
+            storage.addGroupMemberRole(GroupMember(groupId, it, GroupMemberRole.HIDDEN_MODERATOR))
         }
         // - Admins
         pollInfo.details?.admins?.forEach {
-            storage.addGroupMember(GroupMember(groupId, it, GroupMemberRole.ADMIN))
+            storage.addGroupMemberRole(GroupMember(groupId, it, GroupMemberRole.ADMIN))
         }
         pollInfo.details?.hiddenAdmins?.forEach {
-            storage.addGroupMember(GroupMember(groupId, it, GroupMemberRole.HIDDEN_ADMIN))
+            storage.addGroupMemberRole(GroupMember(groupId, it, GroupMemberRole.HIDDEN_ADMIN))
         }
     }
 

--- a/libsession/src/main/java/org/session/libsession/utilities/recipients/Recipient.java
+++ b/libsession/src/main/java/org/session/libsession/utilities/recipients/Recipient.java
@@ -224,6 +224,7 @@ public class Recipient implements RecipientModifiedListener {
             Recipient.this.profileSharing         = result.profileSharing;
             Recipient.this.unidentifiedAccessMode = result.unidentifiedAccessMode;
             Recipient.this.forceSmsSelection      = result.forceSmsSelection;
+            Recipient.this.notifyType             = result.notifyType;
 
             Recipient.this.participants.clear();
             Recipient.this.participants.addAll(result.participants);


### PR DESCRIPTION
There was a async builder for RecipientSettings that didn't set the `notifyType` which might be messing with static Recipient cache and appearing as if the mentions only notify type had been cleared. Also removes member roles on new insertions so it clears out stale mods / admins on refresh