### PR TITLE
Allow user display names of up to 64 bytes.

### DIFF
--- a/libsession/src/main/java/org/session/libsession/utilities/SSKEnvironment.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/SSKEnvironment.kt
@@ -26,7 +26,7 @@ class SSKEnvironment(
 
     interface ProfileManagerProtocol {
         companion object {
-            const val NAME_PADDED_LENGTH = 26
+            const val NAME_PADDED_LENGTH = 64
         }
 
         fun setNickname(context: Context, recipient: Recipient, nickname: String?)


### PR DESCRIPTION
Currently, only 26 bytes are allowed for the user's display name. Whilst this is typically enough for users in the West, it is woefully inadequate for names natively rendered in non-Latin scripts.

Farsi, for example, uses double-byte characters, so 26 bytes can accommodate a maximum of just 13 characters.

The situation is worse yet for Japanese, Korean, Chinese and Thai, each of which uses triple-byte characters for a maximum of just 8 characters.

This patch increases the maximum size of the display name to 64 bytes, good for a minimum of 21 graphemes in even a triple-byte UTF-8 script.

64 bytes also happens to be the maximum length of an ONS registration for Session, and it seems entirely reasonable to allow users to have their ONS name as their display name.

See also [#2514](https://github.com/oxen-io/session-desktop/pull/2514) for the equivalent fix for the desktop client.

### Contributor checklist
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
