### PR TITLE
Fixed a bug where message requests could incorrectly appear in the thread list

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -670,7 +670,6 @@ class Storage(context: Context, helper: SQLCipherOpenHelper) : Database(context,
             val threadId = threadDatabase.getOrCreateThreadIdFor(recipient)
             if (contact.didApproveMe == true) {
                 recipientDatabase.setApprovedMe(recipient, true)
-                threadDatabase.setHasSent(threadId, true)
             }
             if (contact.isApproved == true) {
                 recipientDatabase.setApproved(recipient, true)


### PR DESCRIPTION
There seems to also be an odd case which can occur where a config message isn't always seen as a duplicate, when that happens all message requests start appearing in the normal conversation list due to the `HAS_SENT` flag incorrectly getting set to true (have only fixed the latter - unsure what causes the undetected duplicate message issue).