### PR TITLE
Fix failing PNServerJob issue

### DIFF
--- a/libsession/src/main/java/org/session/libsession/snode/SnodeMessage.kt
+++ b/libsession/src/main/java/org/session/libsession/snode/SnodeMessage.kt
@@ -20,6 +20,7 @@ data class SnodeMessage(
      */
     val timestamp: Long
 ) {
+    internal constructor(): this("", "", -1, -1)
 
     internal fun toJSON(): Map<String, String> {
         return mapOf(


### PR DESCRIPTION
- Added a missing constructor resulting in push notification jobs failing to deserialise when loading them from the database

Resolves one of the error stack traces from the logs in https://github.com/oxen-io/session-android/issues/1094 (though doesn't seem related to the crash)