### PR TITLE
Add ‘Copy community URL’ to the long-press menu

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/home/ConversationOptionsBottomSheet.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/ConversationOptionsBottomSheet.kt
@@ -20,6 +20,7 @@ class ConversationOptionsBottomSheet(private val parentContext: Context) : Botto
     lateinit var thread: ThreadRecord
 
     var onViewDetailsTapped: (() -> Unit?)? = null
+    var onCopyConversationId: (() -> Unit?)? = null
     var onPinTapped: (() -> Unit)? = null
     var onUnpinTapped: (() -> Unit)? = null
     var onBlockTapped: (() -> Unit)? = null
@@ -37,6 +38,8 @@ class ConversationOptionsBottomSheet(private val parentContext: Context) : Botto
     override fun onClick(v: View?) {
         when (v) {
             binding.detailsTextView -> onViewDetailsTapped?.invoke()
+            binding.copyConversationId -> onCopyConversationId?.invoke()
+            binding.copyCommunityUrl -> onCopyConversationId?.invoke()
             binding.pinTextView -> onPinTapped?.invoke()
             binding.unpinTextView -> onUnpinTapped?.invoke()
             binding.blockTextView -> onBlockTapped?.invoke()
@@ -63,6 +66,10 @@ class ConversationOptionsBottomSheet(private val parentContext: Context) : Botto
         } else {
             binding.detailsTextView.visibility = View.GONE
         }
+        binding.copyConversationId.visibility = if (!recipient.isGroupRecipient && !recipient.isLocalNumber) View.VISIBLE else View.GONE
+        binding.copyConversationId.setOnClickListener(this)
+        binding.copyCommunityUrl.visibility = if (recipient.isOpenGroupRecipient) View.VISIBLE else View.GONE
+        binding.copyCommunityUrl.setOnClickListener(this)
         binding.unMuteNotificationsTextView.isVisible = recipient.isMuted && !recipient.isLocalNumber
         binding.muteNotificationsTextView.isVisible = !recipient.isMuted && !recipient.isLocalNumber
         binding.unMuteNotificationsTextView.setOnClickListener(this)

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
@@ -4,6 +4,8 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.os.Bundle
 import android.text.SpannableString
 import android.widget.Toast
@@ -425,6 +427,24 @@ class HomeActivity : PassphraseRequiredActionBarActivity(),
             )
             userDetailsBottomSheet.arguments = bundle
             userDetailsBottomSheet.show(supportFragmentManager, userDetailsBottomSheet.tag)
+        }
+        bottomSheet.onCopyConversationId = onCopyConversationId@{
+            bottomSheet.dismiss()
+            if (!thread.recipient.isGroupRecipient && !thread.recipient.isLocalNumber) {
+                val clip = ClipData.newPlainText("Session ID", thread.recipient.address.toString())
+                val manager = getSystemService(PassphraseRequiredActionBarActivity.CLIPBOARD_SERVICE) as ClipboardManager
+                manager.setPrimaryClip(clip)
+                Toast.makeText(this, R.string.copied_to_clipboard, Toast.LENGTH_SHORT).show()
+            }
+            else if (thread.recipient.isOpenGroupRecipient) {
+                val threadId = threadDb.getThreadIdIfExistsFor(thread.recipient) ?: return@onCopyConversationId Unit
+                val openGroup = DatabaseComponent.get(this@HomeActivity).lokiThreadDatabase().getOpenGroupChat(threadId) ?: return@onCopyConversationId Unit
+
+                val clip = ClipData.newPlainText("Community URL", openGroup.joinURL)
+                val manager = getSystemService(PassphraseRequiredActionBarActivity.CLIPBOARD_SERVICE) as ClipboardManager
+                manager.setPrimaryClip(clip)
+                Toast.makeText(this, R.string.copied_to_clipboard, Toast.LENGTH_SHORT).show()
+            }
         }
         bottomSheet.onBlockTapped = {
             bottomSheet.dismiss()

--- a/app/src/main/res/layout/fragment_conversation_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_conversation_bottom_sheet.xml
@@ -17,6 +17,22 @@
         android:text="@string/details" />
 
     <TextView
+        android:id="@+id/copyConversationId"
+        style="@style/BottomSheetActionItem"
+        android:drawableStart="@drawable/ic_content_copy_white_24dp"
+        android:drawableTint="?attr/colorControlNormal"
+        android:visibility="gone"
+        android:text="@string/activity_conversation_menu_copy_session_id" />
+
+    <TextView
+        android:id="@+id/copyCommunityUrl"
+        style="@style/BottomSheetActionItem"
+        android:drawableStart="@drawable/ic_content_copy_white_24dp"
+        android:drawableTint="?attr/colorControlNormal"
+        android:visibility="gone"
+        android:text="@string/ConversationActivity_copy_open_group_url" />
+
+    <TextView
         android:id="@+id/pinTextView"
         style="@style/BottomSheetActionItem"
         android:drawableStart="?attr/menu_pin_icon"


### PR DESCRIPTION
- Added both 'Copy Session ID' and 'Copy Community URL' to the conversation screen long press menu

Fixes #1020 