### PR TITLE
force run as "foreground service" all the time

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -475,6 +475,11 @@
         <meta-data
             android:name="com.sec.android.multiwindow.MINIMUM_SIZE_H"
             android:value="598.0dip" />
+
+        <service
+            android:name="org.thoughtcrime.securesms.MyForegroundService"
+            android:enabled="true"
+            android:exported="true" />
     </application>
 
 </manifest>

--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -19,6 +19,9 @@ import static nl.komponents.kovenant.android.KovenantAndroid.startKovenant;
 import static nl.komponents.kovenant.android.KovenantAndroid.stopKovenant;
 
 import android.app.Application;
+import android.app.Notification;
+import android.app.PendingIntent;
+import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.os.AsyncTask;
@@ -27,9 +30,11 @@ import android.os.Handler;
 import android.os.HandlerThread;
 
 import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
 import androidx.lifecycle.DefaultLifecycleObserver;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.ProcessLifecycleOwner;
+
 
 import org.conscrypt.Conscrypt;
 import org.session.libsession.avatars.AvatarHelper;
@@ -113,6 +118,7 @@ import dagger.hilt.android.HiltAndroidApp;
 import kotlin.Unit;
 import kotlinx.coroutines.Job;
 import network.loki.messenger.BuildConfig;
+
 
 /**
  * Will be called once when the TextSecure process is created.
@@ -244,6 +250,14 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
     public void onStart(@NonNull LifecycleOwner owner) {
         isAppVisible = true;
         Log.i(TAG, "App is now visible.");
+
+        Intent serviceIntent = new Intent(this, MyForegroundService.class);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Log.i(TAG, "start foreground service");
+            //startService(serviceIntent);
+            startForegroundService(serviceIntent);
+        }
+
         KeyCachingService.onAppForegrounded(this);
 
         // If the user account hasn't been created or onboarding wasn't finished then don't start
@@ -267,11 +281,12 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
     public void onStop(@NonNull LifecycleOwner owner) {
         isAppVisible = false;
         Log.i(TAG, "App is no longer visible.");
+
         KeyCachingService.onAppBackgrounded(this);
         messageNotifier.setVisibleThread(-1);
-        if (poller != null) {
+        /*if (poller != null) {
             poller.stopIfNeeded();
-        }
+        }*/
         ClosedGroupPollerV2.getShared().stop();
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -287,13 +287,13 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
         /*if (poller != null) {
             poller.stopIfNeeded();
         }*/
-        ClosedGroupPollerV2.getShared().stop();
+        //ClosedGroupPollerV2.getShared().stop();
     }
 
     @Override
     public void onTerminate() {
         stopKovenant(); // Loki
-        OpenGroupManager.INSTANCE.stopPolling();
+        //OpenGroupManager.INSTANCE.stopPolling();
         super.onTerminate();
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/MyForegroundService.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/MyForegroundService.kt
@@ -1,0 +1,52 @@
+package org.thoughtcrime.securesms
+
+import android.app.*
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import network.loki.messenger.R
+
+
+class MyForegroundService: Service() {
+    val CHANNEL_ID = "ForegroundServiceChannel"
+
+    override fun onBind(intent: Intent): IBinder? {
+        throw UnsupportedOperationException("Not yet implemented")
+    }
+
+    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+
+        createNotificationChannel()
+        val notificationIntent = Intent(this, ApplicationContext::class.java)
+
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0, notificationIntent, 0
+        )
+        val notification: Notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Running in background")
+            .setSmallIcon(R.drawable.ic_notification)
+            //.setContentIntent(pendingIntent)
+            .setSilent(true)
+            .setShowWhen(false)
+            .build()
+        startForeground(1, notification)
+
+        return START_NOT_STICKY
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val serviceChannel = NotificationChannel(
+                CHANNEL_ID,
+                "Foreground Service Channel",
+                NotificationManager.IMPORTANCE_DEFAULT
+            )
+            //serviceChannel.setSound(null, null)
+            val notificationManager = getSystemService(NotificationManager::class.java)
+            notificationManager.createNotificationChannel(serviceChannel)
+        }
+    }
+}


### PR DESCRIPTION
This is the bare minimum to run as a "foreground service". Ideally there would be an option in Settings->Notifications to enable this as a third option after Push & Polling.

I don't recommend this PR be merged into the mainline branch. But others may like to merge and compile themselves to activate foreground service.