### PR TITLE
Fix LandingActivity textColor

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -228,11 +228,13 @@
     <style name="FakeChatViewMessageBubble.Incoming">
         <item name="android:background">@drawable/fake_chat_view_incoming_message_background</item>
         <item name="android:elevation">10dp</item>
+        <item name="android:textColor">?message_received_text_color</item>
     </style>
 
     <style name="FakeChatViewMessageBubble.Outgoing">
         <item name="android:background">@drawable/fake_chat_view_outgoing_message_background</item>
         <item name="android:elevation">10dp</item>
+        <item name="android:textColor">?message_sent_text_color</item>
     </style>
     <!-- Session -->
 


### PR DESCRIPTION
The white text on green in the LandingActivity appears to be a mistake and deviates from convention in the `ConversationActivity`. This PR is intended to bring colors in-line with `ConversationActivity` and make this text readable.

# before
<img width="287" alt="Screen Shot 2023-04-20 at 9 12 50 pm" src="https://user-images.githubusercontent.com/9282178/233355929-4b619f66-c187-490f-a7ae-67463e8315c0.png">

# after
<img width="287" alt="Screen Shot 2023-04-20 at 9 10 21 pm" src="https://user-images.githubusercontent.com/9282178/233355405-684eada5-cd59-4e5c-b25e-99f8b88a1ea4.png">