### PR TITLE
Fix status and nav bar colors

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/BaseActionBarActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/BaseActionBarActivity.java
@@ -1,5 +1,6 @@
 package org.thoughtcrime.securesms;
 
+import static android.os.Build.VERSION.SDK_INT;
 import static org.session.libsession.utilities.TextSecurePreferences.SELECTED_ACCENT_COLOR;
 
 import android.app.ActivityManager;
@@ -18,6 +19,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import org.session.libsession.utilities.TextSecurePreferences;
 import org.session.libsession.utilities.dynamiclanguage.DynamicLanguageActivityHelper;
 import org.session.libsession.utilities.dynamiclanguage.DynamicLanguageContextWrapper;
+import org.thoughtcrime.securesms.conversation.v2.WindowUtil;
 import org.thoughtcrime.securesms.util.ActivityUtilitiesKt;
 import org.thoughtcrime.securesms.util.ThemeState;
 import org.thoughtcrime.securesms.util.UiModeUtilities;
@@ -92,6 +94,11 @@ public abstract class BaseActionBarActivity extends AppCompatActivity {
     if (!currentThemeState.equals(ActivityUtilitiesKt.themeState(getPreferences()))) {
       recreate();
     }
+
+    // apply lightStatusBar manually as API 26 does not update properly via applyTheme
+    // https://issuetracker.google.com/issues/65883460?pli=1
+    if (SDK_INT >= 26 && SDK_INT <= 27) WindowUtil.setLightStatusBarFromTheme(this);
+    if (SDK_INT == 27) WindowUtil.setLightNavigationBarFromTheme(this);
   }
 
   @Override

--- a/app/src/main/res/values-v27/colors.xml
+++ b/app/src/main/res/values-v27/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="classic_light_navigation_bar">@color/classic_light_6</color>
+    <color name="ocean_light_navigation_bar">@color/ocean_light_7</color>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -60,6 +60,9 @@
     <color name="transparent_white_40">#40ffffff</color>
     <color name="transparent_white_aa">#aaffffff</color>
 
+    <color name="navigation_bar">@color/compose_view_background</color>
+    <color name="classic_light_navigation_bar">@color/navigation_bar</color>
+    <color name="ocean_light_navigation_bar">@color/navigation_bar</color>
     <color name="action_mode_status_bar">@color/gray65</color>
     <color name="touch_highlight">#22000000</color>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -326,7 +326,7 @@
         <item name="android:textColor">?android:textColorPrimary</item>
         <item name="android:textColorHint">@color/gray27</item>
         <item name="android:windowBackground">?colorPrimary</item>
-        <item name="android:navigationBarColor">@color/compose_view_background</item>
+        <item name="android:navigationBarColor">@color/navigation_bar</item>
         <item name="dialog_background_color">@color/classic_dark_1</item>
         <item name="bottomSheetDialogTheme">@style/Classic.Dark.BottomSheet</item>
         <item name="actionMenuTextColor">?android:textColorPrimary</item>
@@ -404,7 +404,7 @@
         <item name="android:textColor">?android:textColorPrimary</item>
         <item name="android:textColorHint">@color/gray27</item>
         <item name="android:windowBackground">?colorPrimary</item>
-        <item name="android:navigationBarColor">?colorPrimary</item>
+        <item name="android:navigationBarColor">@color/classic_light_navigation_bar</item>
         <item name="colorCellBackground">@color/classic_light_6</item>
         <item name="colorSettingsBackground">@color/classic_light_5</item>
         <item name="colorDividerBackground">@color/classic_light_3</item>
@@ -490,7 +490,7 @@
         <item name="android:textColorHint">@color/ocean_dark_5</item>
         <item name="android:windowBackground">?colorPrimary</item>
         <item name="android:colorBackground">@color/default_background_start</item>
-        <item name="android:navigationBarColor">@color/compose_view_background</item>
+        <item name="android:navigationBarColor">@color/navigation_bar</item>
         <item name="default_background_end">?colorPrimary</item>
         <item name="default_background_start">?colorPrimaryDark</item>
         <item name="colorCellBackground">@color/ocean_dark_3</item>
@@ -570,7 +570,7 @@
         <item name="android:textColorTertiary">@color/ocean_light_2</item>
         <item name="android:textColor">?android:textColorPrimary</item>
         <item name="android:textColorHint">@color/ocean_light_6</item>
-        <item name="android:navigationBarColor">@color/ocean_light_7</item>
+        <item name="android:navigationBarColor">@color/ocean_light_navigation_bar</item>
         <item name="android:windowBackground">?colorPrimary</item>
         <item name="android:colorBackground">@color/default_background_start</item>
         <item name="default_background_end">@color/ocean_light_7</item>


### PR DESCRIPTION
Navigation Buttons are not visible below API 25, because they are always white. We need to keep the nav bar dark on these apis.

Colors for v27 nav bars are found in `values-v27/colors`

Status bars on 26 and 27 and nav bars on 27 are not reset properly when set with a theme created using `applyTheme`. see [here](https://issuetracker.google.com/issues/65883460?pli=1).  So I've added conditional code to `BaseActionBarActivity` to set them properly.

# Here are images exhibiting the issues this PR solves.

## API 23 (up to 25)

Bad nav bar on light theme

<img width="631" alt="23dark" src="https://user-images.githubusercontent.com/9282178/233990953-a29e210a-b6ed-46d0-ad00-36266d247351.png">


<img width="598" alt="23lite" src="https://user-images.githubusercontent.com/9282178/233990830-6092c0c4-4d91-4a4e-ac04-cf774c16bdcb.png">

## API 26

bad nav bar on light theme AND bad status bar on dark theme

<img width="539" alt="26dark" src="https://user-images.githubusercontent.com/9282178/233991056-da782a0d-0337-4e97-8e29-a1b890cdd812.png">

<img width="537" alt="26lite" src="https://user-images.githubusercontent.com/9282178/233991091-4bf498e2-2000-46f1-a633-f6f4845f8d90.png">

## API 27

 bad status and nav bar on dark theme

<img width="475" alt="27dark" src="https://user-images.githubusercontent.com/9282178/233991271-a942b924-f198-4a14-bc22-6370dd6a0d8e.png">

<img width="471" alt="27lite" src="https://user-images.githubusercontent.com/9282178/233991285-14cf1bc8-fd8d-4d1b-ab3f-9418e525fff7.png">

## API 28+

all good.
