### PR TITLE
Add SafeViewPager to fix touch exception in MediaPreviewActivity

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/SafeViewPager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/SafeViewPager.kt
@@ -1,0 +1,30 @@
+package org.thoughtcrime.securesms.components
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MotionEvent
+import androidx.viewpager.widget.ViewPager
+
+/**
+ * An extension of ViewPager to swallow erroneous multi-touch exceptions.
+ *
+ * @see https://stackoverflow.com/questions/6919292/pointerindex-out-of-range-android-multitouch
+ */
+class SafeViewPager @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : ViewPager(context, attrs) {
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onTouchEvent(event: MotionEvent?): Boolean = try {
+        super.onTouchEvent(event)
+    } catch (e: IllegalArgumentException) {
+        false
+    }
+
+    override fun onInterceptTouchEvent(event: MotionEvent?): Boolean = try {
+        super.onInterceptTouchEvent(event)
+    } catch (e: IllegalArgumentException) {
+        false
+    }
+}

--- a/app/src/main/res/layout/media_preview_activity.xml
+++ b/app/src/main/res/layout/media_preview_activity.xml
@@ -22,7 +22,7 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.viewpager.widget.ViewPager
+    <org.thoughtcrime.securesms.components.SafeViewPager
         android:id="@+id/media_pager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"


### PR DESCRIPTION
The old `ViewPager` doesn't behave well with zoom and scale gesture detection in its child views.

`SafeViewPager` catches and ignores exceptions thrown when `ViewPager` would retrieve position of stale or non-existent touches.

We could have alternatively used `ViewPager2` or `RecyclerView` but that would be an extensive refactor and may involve refactoring `CursorAdapter`s to be `RecyclerView.Adapter`s.