### PR TITLE
Swallow exceptions in ScreenshotObserver

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/attachments/ScreenshotObserver.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/attachments/ScreenshotObserver.kt
@@ -7,6 +7,10 @@ import android.os.Build
 import android.os.Handler
 import android.provider.MediaStore
 import androidx.annotation.RequiresApi
+import org.session.libsignal.utilities.Log
+import org.thoughtcrime.securesms.jobmanager.impl.JsonDataSerializer
+
+private const val TAG = "ScreenshotObserver"
 
 class ScreenshotObserver(private val context: Context, handler: Handler, private val screenshotTriggered: ()->Unit): ContentObserver(handler) {
 
@@ -31,22 +35,26 @@ class ScreenshotObserver(private val context: Context, handler: Handler, private
         val projection = arrayOf(
             MediaStore.Images.Media.DATA
         )
-        context.contentResolver.query(
-            uri,
-            projection,
-            null,
-            null,
-            null
-        )?.use { cursor ->
-            val dataColumn = cursor.getColumnIndex(MediaStore.Images.Media.DATA)
-            while (cursor.moveToNext()) {
-                val path = cursor.getString(dataColumn)
-                if (path.contains("screenshot", true)) {
-                    if (cache.add(uri.hashCode())) {
-                        screenshotTriggered()
+        try {
+            context.contentResolver.query(
+                uri,
+                projection,
+                null,
+                null,
+                null
+            )?.use { cursor ->
+                val dataColumn = cursor.getColumnIndex(MediaStore.Images.Media.DATA)
+                while (cursor.moveToNext()) {
+                    val path = cursor.getString(dataColumn)
+                    if (path.contains("screenshot", true)) {
+                        if (cache.add(uri.hashCode())) {
+                            screenshotTriggered()
+                        }
                     }
                 }
             }
+        } catch (e: SecurityException) {
+            Log.e(TAG, e)
         }
     }
 
@@ -56,28 +64,32 @@ class ScreenshotObserver(private val context: Context, handler: Handler, private
             MediaStore.Images.Media.DISPLAY_NAME,
             MediaStore.Images.Media.RELATIVE_PATH
         )
-        context.contentResolver.query(
-            uri,
-            projection,
-            null,
-            null,
-            null
-        )?.use { cursor ->
-            val relativePathColumn =
-                cursor.getColumnIndex(MediaStore.Images.Media.RELATIVE_PATH)
-            val displayNameColumn =
-                cursor.getColumnIndex(MediaStore.Images.Media.DISPLAY_NAME)
-            while (cursor.moveToNext()) {
-                val name = cursor.getString(displayNameColumn)
-                val relativePath = cursor.getString(relativePathColumn)
-                if (name.contains("screenshot", true) or
-                    relativePath.contains("screenshot", true)) {
-                    if (cache.add(uri.hashCode())) {
-                        screenshotTriggered()
+
+        try {
+            context.contentResolver.query(
+                uri,
+                projection,
+                null,
+                null,
+                null
+            )?.use { cursor ->
+                val relativePathColumn =
+                    cursor.getColumnIndex(MediaStore.Images.Media.RELATIVE_PATH)
+                val displayNameColumn =
+                    cursor.getColumnIndex(MediaStore.Images.Media.DISPLAY_NAME)
+                while (cursor.moveToNext()) {
+                    val name = cursor.getString(displayNameColumn)
+                    val relativePath = cursor.getString(relativePathColumn)
+                    if (name.contains("screenshot", true) or
+                        relativePath.contains("screenshot", true)) {
+                        if (cache.add(uri.hashCode())) {
+                            screenshotTriggered()
+                        }
                     }
                 }
             }
+        } catch (e: IllegalStateException) {
+            Log.e(TAG, e)
         }
     }
-
 }


### PR DESCRIPTION
Swallow exceptions in `ScreenshotObserver` occurring mainly on Huawei and Samsung devices.

It's probably a permissions issue, as we do not explicitly request storage permissions before initialising ScreenshotObserver.

## API 29+

```
Exception java.lang.IllegalStateException: Unknown URL: content://media/ is hidden API
  at android.os.Parcel.createException (Parcel.java:2099)
  at android.os.Parcel.readException (Parcel.java:2059)
  at android.database.DatabaseUtils.readExceptionFromParcel (DatabaseUtils.java:188)
  at android.database.DatabaseUtils.readExceptionFromParcel (DatabaseUtils.java:140)
  at android.content.ContentProviderProxy.query (ContentProviderNative.java:423)
  at android.content.ContentResolver.query (ContentResolver.java:955)
  at android.content.ContentResolver.query (ContentResolver.java:891)
  at android.content.ContentResolver.query (ContentResolver.java:840)
  at org.thoughtcrime.securesms.attachments.ScreenshotObserver.queryRelativeDataColumn (ScreenshotObserver.kt:54)
  at org.thoughtcrime.securesms.attachments.ScreenshotObserver.onChange (ScreenshotObserver.kt:17)
  at android.database.ContentObserver.onChange (ContentObserver.java:147)
  at android.database.ContentObserver$NotificationRunnable.run (ContentObserver.java:218)
  at android.os.Handler.handleCallback (Handler.java:900)
  at android.os.Handler.dispatchMessage (Handler.java:103)
  at android.os.Looper.loop (Looper.java:219)
  at android.app.ActivityThread.main (ActivityThread.java:8668)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:513)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1109)
```

## prior

```
Exception java.lang.SecurityException:
  at android.os.Parcel.readException (Parcel.java:2029)
  at android.database.DatabaseUtils.readExceptionFromParcel (DatabaseUtils.java:183)
  at android.database.DatabaseUtils.readExceptionFromParcel (DatabaseUtils.java:135)
  at android.content.ContentProviderProxy.query (ContentProviderNative.java:418)
  at android.content.ContentResolver.query (ContentResolver.java:760)
  at android.content.ContentResolver.query (ContentResolver.java:710)
  at android.content.ContentResolver.query (ContentResolver.java:668)
  at org.thoughtcrime.securesms.attachments.ScreenshotObserver.queryDataColumn (ScreenshotObserver.kt:29)
  at org.thoughtcrime.securesms.attachments.ScreenshotObserver.onChange (ScreenshotObserver.kt:19)
  at android.database.ContentObserver.onChange (ContentObserver.java:145)
  at android.database.ContentObserver$NotificationRunnable.run (ContentObserver.java:216)
  at android.os.Handler.handleCallback (Handler.java:790)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:164)
  at android.app.ActivityThread.main (ActivityThread.java:7025)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:441)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1408)
```