### PR TITLE
Add IOpenGroup to deduplicate LegacyOpenGroup

### DIFF
--- a/libsession/src/main/java/org/session/libsession/messaging/messages/Destination.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/messages/Destination.kt
@@ -7,23 +7,22 @@ import org.session.libsignal.utilities.toHexString
 
 sealed class Destination {
 
-    class Contact(var publicKey: String) : Destination() {
-        internal constructor(): this("")
-    }
-    class ClosedGroup(var groupPublicKey: String) : Destination() {
-        internal constructor(): this("")
-    }
-    class LegacyOpenGroup(var roomToken: String, var server: String) : Destination() {
-        internal constructor(): this("", "")
+    class Contact(var publicKey: String) : Destination()
+    class ClosedGroup(var groupPublicKey: String) : Destination()
+    class LegacyOpenGroup(override var roomToken: String, override var server: String) : IOpenGroup, Destination()
+
+    interface IOpenGroup {
+        val roomToken: String
+        val server: String
     }
 
     class OpenGroup(
-        var roomToken: String = "",
-        var server: String = "",
+        override var roomToken: String = "",
+        override var server: String = "",
         var whisperTo: List<String> = emptyList(),
         var whisperMods: Boolean = false,
         var fileIds: List<String> = emptyList()
-    ) : Destination()
+    ) : IOpenGroup, Destination()
 
     class OpenGroupInbox(
         var server: String,


### PR DESCRIPTION
This PR simplifies some deduplicated code around handling `LegacyOpenGroup` and `OpenGroup`s by pulling out their common fields into new interface `IOpenGroup`.