### PR TITLE
Fix scroll to bottom button position when input not visible

### DIFF
--- a/app/src/main/res/layout/activity_conversation_v2.xml
+++ b/app/src/main/res/layout/activity_conversation_v2.xml
@@ -137,6 +137,7 @@
         android:layout_height="50dp"
         android:layout_alignParentEnd="true"
         android:layout_above="@+id/messageRequestBar"
+        android:layout_alignWithParentIfMissing="true"
         android:layout_marginEnd="12dp"
         android:layout_marginBottom="32dp">
 


### PR DESCRIPTION
If the input bar is not visible, the scroll to bottom button is not anchored properly.

![Screenshot_20230509_104710](https://user-images.githubusercontent.com/9282178/236970055-d4b4fe22-d9da-415e-acb2-64d71d1eee89.png)
