### PR TITLE
Fix ripple color

### DIFF
--- a/app/src/main/res/drawable/conversation_pinned_background.xml
+++ b/app/src/main/res/drawable/conversation_pinned_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?colorCellRipple">
+    android:color="?android:colorControlHighlight">
 
     <item>
         <color android:color="?conversation_pinned_background_color" />

--- a/app/src/main/res/drawable/conversation_unread_background.xml
+++ b/app/src/main/res/drawable/conversation_unread_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?colorCellRipple">
+    android:color="?android:colorControlHighlight">
 
     <item>
         <color android:color="?conversation_unread_background_color" />

--- a/app/src/main/res/drawable/conversation_view_background.xml
+++ b/app/src/main/res/drawable/conversation_view_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?colorCellRipple">
+    android:color="?android:colorControlHighlight">
 
     <item>
         <color android:color="?colorCellBackground" />

--- a/app/src/main/res/drawable/mention_candidate_view_background.xml
+++ b/app/src/main/res/drawable/mention_candidate_view_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?mention_candidates_view_background_ripple">
+    android:color="?android:colorControlHighlight">
 
     <item>
         <color android:color="?mention_candidates_view_background" />

--- a/app/src/main/res/drawable/setting_button_background.xml
+++ b/app/src/main/res/drawable/setting_button_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?colorCellRipple">
+    android:color="?android:colorControlHighlight">
 
     <item>
         <color android:color="?colorCellBackground" />

--- a/app/src/main/res/layout/blocked_contact_layout.xml
+++ b/app/src/main/res/layout/blocked_contact_layout.xml
@@ -7,7 +7,6 @@
     android:paddingHorizontal="@dimen/medium_spacing"
     android:paddingVertical="@dimen/small_spacing"
     android:gravity="center_vertical"
-    android:background="?selectableItemBackground"
     android:id="@+id/backgroundContainer">
     <include layout="@layout/view_profile_picture"
         android:id="@+id/profilePictureView"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -150,7 +150,6 @@
     <attr name="conversation_shadow_main" format="color|reference"/>
     <attr name="default_background_start" format="color|reference"/>
     <attr name="default_background_end" format="color|reference"/>
-    <attr name="colorCellRipple" format="color|reference"/>
     <attr name="colorCellBackground" format="color|reference" />
     <attr name="colorSettingsBackground" format="color|reference" />
     <attr name="colorDividerBackground" format="color|reference" />
@@ -176,7 +175,6 @@
     <attr name="input_bar_lock_view_background" format="color|reference"/>
     <attr name="input_bar_lock_view_border" format="color|reference"/>
     <attr name="mention_candidates_view_background" format="color|reference"/>
-    <attr name="mention_candidates_view_background_ripple" format="color|reference"/>
     <attr name="scroll_to_bottom_button_background" format="color|reference"/>
     <attr name="scroll_to_bottom_button_border" format="color|reference"/>
     <attr name="conversation_unread_count_indicator_background" format="color|reference"/>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -319,7 +319,6 @@
         <item name="colorPrimaryDark">@color/classic_dark_0</item>
         <item name="colorControlNormal">?android:textColorPrimary</item>
         <item name="colorControlActivated">?colorAccent</item>
-        <item name="android:colorControlHighlight">?colorAccent</item>
         <item name="android:textColorPrimary">@color/classic_dark_6</item>
         <item name="android:textColorSecondary">?android:textColorPrimary</item>
         <item name="android:textColorTertiary">@color/classic_dark_5</item>
@@ -334,7 +333,7 @@
         <item name="colorCellBackground">@color/classic_dark_1</item>
         <item name="colorSettingsBackground">@color/classic_dark_1</item>
         <item name="colorDividerBackground">@color/classic_dark_3</item>
-        <item name="colorCellRipple">@color/classic_dark_3</item>
+        <item name="android:colorControlHighlight">@color/classic_dark_3</item>
         <item name="actionBarPopupTheme">@style/Dark.Popup</item>
         <item name="actionBarWidgetTheme">@null</item>
         <item name="actionBarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
@@ -382,7 +381,6 @@
         <item name="input_bar_lock_view_background">@color/classic_dark_2</item>
         <item name="input_bar_lock_view_border">@color/classic_dark_3</item>
         <item name="mention_candidates_view_background">@color/classic_dark_2</item>
-        <item name="mention_candidates_view_background_ripple">@color/classic_dark_3</item>
         <item name="scroll_to_bottom_button_background">@color/classic_dark_1</item>
         <item name="scroll_to_bottom_button_border">@color/classic_dark_3</item>
         <item name="conversation_unread_count_indicator_background">@color/classic_dark_4</item>
@@ -397,7 +395,6 @@
         <item name="colorPrimaryDark">@color/classic_light_6</item>
         <item name="colorControlNormal">?android:textColorPrimary</item>
         <item name="colorControlActivated">?colorAccent</item>
-        <item name="android:colorControlHighlight">?colorAccent</item>
         <item name="android:textColorPrimary">@color/classic_light_0</item>
         <item name="android:textColorSecondary">@color/classic_light_1</item>
         <item name="android:textColorTertiary">@color/classic_light_1</item>
@@ -408,7 +405,7 @@
         <item name="colorCellBackground">@color/classic_light_6</item>
         <item name="colorSettingsBackground">@color/classic_light_5</item>
         <item name="colorDividerBackground">@color/classic_light_3</item>
-        <item name="colorCellRipple">@color/classic_light_3</item>
+        <item name="android:colorControlHighlight">@color/classic_light_3</item>
         <item name="bottomSheetDialogTheme">@style/Classic.Light.BottomSheet</item>
         <item name="android:actionMenuTextColor">?android:textColorPrimary</item>
         <item name="popupTheme">?actionBarPopupTheme</item>
@@ -467,7 +464,6 @@
         <item name="input_bar_lock_view_background">@color/classic_light_4</item>
         <item name="input_bar_lock_view_border">@color/classic_light_2</item>
         <item name="mention_candidates_view_background">?colorCellBackground</item>
-        <item name="mention_candidates_view_background_ripple">?colorCellRipple</item>
         <item name="scroll_to_bottom_button_background">@color/classic_light_4</item>
         <item name="scroll_to_bottom_button_border">@color/classic_light_2</item>
         <item name="conversation_unread_count_indicator_background">@color/classic_dark_4</item>
@@ -482,7 +478,6 @@
         <item name="colorPrimaryDark">@color/ocean_dark_2</item>
         <item name="colorControlNormal">@color/ocean_dark_7</item>
         <item name="colorControlActivated">?colorAccent</item>
-        <item name="android:colorControlHighlight">?colorAccent</item>
         <item name="android:textColorPrimary">@color/ocean_dark_7</item>
         <item name="android:textColorSecondary">@color/ocean_dark_5</item>
         <item name="android:textColorTertiary">@color/ocean_dark_5</item>
@@ -496,7 +491,7 @@
         <item name="colorCellBackground">@color/ocean_dark_3</item>
         <item name="colorSettingsBackground">@color/ocean_dark_1</item>
         <item name="colorDividerBackground">@color/ocean_dark_4</item>
-        <item name="colorCellRipple">@color/ocean_dark_4</item>
+        <item name="android:colorControlHighlight">@color/ocean_dark_4</item>
         <item name="bottomSheetDialogTheme">@style/Ocean.Dark.BottomSheet</item>
         <item name="popupTheme">?actionBarPopupTheme</item>
         <item name="actionMenuTextColor">?android:textColorPrimary</item>
@@ -549,7 +544,6 @@
         <item name="input_bar_lock_view_background">?colorPrimary</item>
         <item name="input_bar_lock_view_border">?colorPrimary</item>
         <item name="mention_candidates_view_background">@color/ocean_dark_2</item>
-        <item name="mention_candidates_view_background_ripple">@color/ocean_dark_3</item>
         <item name="scroll_to_bottom_button_background">@color/ocean_dark_4</item>
         <item name="scroll_to_bottom_button_border">?colorPrimary</item>
         <item name="conversation_unread_count_indicator_background">@color/ocean_dark_4</item>
@@ -564,7 +558,6 @@
         <item name="colorPrimaryDark">@color/ocean_light_6</item>
         <item name="colorControlNormal">@color/ocean_light_1</item>
         <item name="colorControlActivated">?colorAccent</item>
-        <item name="android:colorControlHighlight">?colorAccent</item>
         <item name="android:textColorPrimary">@color/ocean_light_1</item>
         <item name="android:textColorSecondary">@color/ocean_light_2</item>
         <item name="android:textColorTertiary">@color/ocean_light_2</item>
@@ -578,7 +571,7 @@
         <item name="colorCellBackground">@color/ocean_light_5</item>
         <item name="colorSettingsBackground">@color/ocean_light_6</item>
         <item name="colorDividerBackground">@color/ocean_light_3</item>
-        <item name="colorCellRipple">@color/ocean_light_4</item>
+        <item name="android:colorControlHighlight">@color/ocean_light_4</item>
         <item name="bottomSheetDialogTheme">@style/Ocean.Light.BottomSheet</item>
         <item name="actionBarPopupTheme">@style/Light.Popup</item>
         <item name="popupTheme">?actionBarPopupTheme</item>
@@ -633,7 +626,6 @@
         <item name="input_bar_lock_view_background">@color/ocean_light_5</item>
         <item name="input_bar_lock_view_border">@color/ocean_light_1</item>
         <item name="mention_candidates_view_background">?colorCellBackground</item>
-        <item name="mention_candidates_view_background_ripple">?colorCellRipple</item>
         <item name="scroll_to_bottom_button_background">?input_bar_button_background_opaque</item>
         <item name="scroll_to_bottom_button_border">?input_bar_button_background_opaque_border</item>
         <item name="conversation_unread_count_indicator_background">?colorAccent</item>


### PR DESCRIPTION
This PR addresses a green ripple on the Preferences screen, by setting the appropriate `android:colorControlHighlight` and removing `colorCellRipple` and `mention_candidates_view_background_ripple` which were mostly just referencing the same as `android:colorControlHighlight` anyway.