### PR TITLE
feat: increase voice recording limit to 5m

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -1573,7 +1573,7 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
             showVoiceMessageUI()
             window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
             audioRecorder.startRecording()
-            stopAudioHandler.postDelayed(stopVoiceMessageRecordingTask, 60000) // Limit voice messages to 1 minute each
+            stopAudioHandler.postDelayed(stopVoiceMessageRecordingTask, 300000) // Limit voice messages to 5 minute each
         } else {
             Permissions.with(this)
                 .request(Manifest.permission.RECORD_AUDIO)


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [ ] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

* [session-android: stops recording after 1 minute](https://github.com/oxen-io/session-android/blob/7b0c0147917655c88782e21eb0321ab16671ad78/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt#L1576)
* [session-desktop: 5 minutes (stated to result in 1.97 MiB)](https://github.com/oxen-io/session-desktop/blob/9310b43394f82c84531c700d988f82be310a3c78/ts/session/constants.ts#L39-L41)

i just took a sample on android and i got 257KiB from a 55s long recording.
this would mean we could actually record 431s (`1.97 * 1024/(257/55 * 60) * 60`) before the file exceeds 1.97MiB. this assumes a constant bitrate and i'm not sure that's realistic. it seems realistic to assume that upping the duration limit to 5 minutes on session-android would not exceed the 1.97MiB that seem applied on session-desktop.

fixes #1182.
