### PR TITLE
Disable unblock button

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/RecipientDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/RecipientDatabase.java
@@ -276,7 +276,7 @@ public class RecipientDatabase extends Database {
     notifyRecipientListeners();
   }
 
-  public void setBlocked(@NonNull List<Recipient> recipients, boolean blocked) {
+  public void setBlocked(@NonNull Iterable<Recipient> recipients, boolean blocked) {
     SQLiteDatabase db = getWritableDatabase();
     db.beginTransaction();
     try {

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -1010,7 +1010,7 @@ class Storage(context: Context, helper: SQLCipherOpenHelper) : Database(context,
         DatabaseComponent.get(context).reactionDatabase().deleteMessageReactions(MessageId(messageId, mms))
     }
 
-    override fun unblock(toUnblock: List<Recipient>) {
+    override fun unblock(toUnblock: Iterable<Recipient>) {
         val recipientDb = DatabaseComponent.get(context).recipientDatabase()
         recipientDb.setBlocked(toUnblock, false)
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsActivity.kt
@@ -27,13 +27,8 @@ class BlockedContactsActivity: PassphraseRequiredActionBarActivity() {
         AlertDialog.Builder(this)
             .setTitle(title)
             .setMessage(message)
-            .setPositiveButton(R.string.continue_2) { d, _ ->
-                viewModel.unblock()
-                d.dismiss()
-            }
-            .setNegativeButton(R.string.cancel) { d, _ ->
-                d.dismiss()
-            }
+            .setPositiveButton(R.string.continue_2) { _, _ -> viewModel.unblock() }
+            .setNegativeButton(R.string.cancel) { _, _ -> }
             .show()
     }
 
@@ -46,7 +41,7 @@ class BlockedContactsActivity: PassphraseRequiredActionBarActivity() {
 
         viewModel.subscribe(this)
             .observe(this) { state ->
-                adapter.submitList(state.blockedContacts)
+                adapter.submitList(state.items)
                 binding.emptyStateMessageTextView.isVisible = state.emptyStateMessageTextViewVisible
                 binding.nonEmptyStateGroup.isVisible = state.nonEmptyStateGroupVisible
                 binding.unblockButton.isEnabled = state.unblockButtonEnabled

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsActivity.kt
@@ -2,7 +2,6 @@ package org.thoughtcrime.securesms.preferences
 
 import android.app.AlertDialog
 import android.os.Bundle
-import android.view.View
 import androidx.activity.viewModels
 import androidx.core.view.isVisible
 import dagger.hilt.android.AndroidEntryPoint
@@ -11,58 +10,31 @@ import network.loki.messenger.databinding.ActivityBlockedContactsBinding
 import org.thoughtcrime.securesms.PassphraseRequiredActionBarActivity
 
 @AndroidEntryPoint
-class BlockedContactsActivity: PassphraseRequiredActionBarActivity(), View.OnClickListener {
+class BlockedContactsActivity: PassphraseRequiredActionBarActivity() {
 
     lateinit var binding: ActivityBlockedContactsBinding
 
     val viewModel: BlockedContactsViewModel by viewModels()
 
-    val adapter = BlockedContactsAdapter()
+    val adapter: BlockedContactsAdapter by lazy { BlockedContactsAdapter(viewModel) }
 
-    override fun onClick(v: View?) {
-        if (v === binding.unblockButton && adapter.getSelectedItems().isNotEmpty()) {
-            val contactsToUnblock = adapter.getSelectedItems()
-            // show dialog
-            val title = if (contactsToUnblock.size == 1) {
-                getString(R.string.Unblock_dialog__title_single, contactsToUnblock.first().name)
-            } else {
-                getString(R.string.Unblock_dialog__title_multiple)
+    fun unblock() {
+        // show dialog
+        val title = viewModel.getTitle(this)
+
+        val message = viewModel.getMessage(this)
+
+        AlertDialog.Builder(this)
+            .setTitle(title)
+            .setMessage(message)
+            .setPositiveButton(R.string.continue_2) { d, _ ->
+                viewModel.unblock()
+                d.dismiss()
             }
-
-            val message = if (contactsToUnblock.size == 1) {
-                getString(R.string.Unblock_dialog__message, contactsToUnblock.first().name)
-            } else {
-                val stringBuilder = StringBuilder()
-                val iterator = contactsToUnblock.iterator()
-                var numberAdded = 0
-                while (iterator.hasNext() && numberAdded < 3) {
-                    val nextRecipient = iterator.next()
-                    if (numberAdded > 0) stringBuilder.append(", ")
-                    
-                    stringBuilder.append(nextRecipient.name)
-                    numberAdded++
-                }
-                val overflow = contactsToUnblock.size - numberAdded
-                if (overflow > 0) {
-                    stringBuilder.append(" ")
-                    val string = resources.getQuantityString(R.plurals.Unblock_dialog__message_multiple_overflow, overflow)
-                    stringBuilder.append(string.format(overflow))
-                }
-                getString(R.string.Unblock_dialog__message, stringBuilder.toString())
+            .setNegativeButton(R.string.cancel) { d, _ ->
+                d.dismiss()
             }
-
-            AlertDialog.Builder(this)
-                .setTitle(title)
-                .setMessage(message)
-                .setPositiveButton(R.string.continue_2) { d, _ ->
-                    viewModel.unblock(contactsToUnblock)
-                    d.dismiss()
-                }
-                .setNegativeButton(R.string.cancel) { d, _ ->
-                    d.dismiss()
-                }
-                .show()
-        }
+            .show()
     }
 
     override fun onCreate(savedInstanceState: Bundle?, ready: Boolean) {
@@ -73,15 +45,15 @@ class BlockedContactsActivity: PassphraseRequiredActionBarActivity(), View.OnCli
         binding.recyclerView.adapter = adapter
 
         viewModel.subscribe(this)
-            .observe(this) { newState ->
-                adapter.submitList(newState.blockedContacts)
-                val isEmpty = newState.blockedContacts.isEmpty()
-                binding.emptyStateMessageTextView.isVisible = isEmpty
-                binding.nonEmptyStateGroup.isVisible = !isEmpty
+            .observe(this) { state ->
+                adapter.submitList(state.blockedContacts)
+                binding.emptyStateMessageTextView.isVisible = state.emptyStateMessageTextViewVisible
+                binding.nonEmptyStateGroup.isVisible = state.nonEmptyStateGroupVisible
+                binding.unblockButton.isEnabled = state.unblockButtonEnabled
             }
 
-        binding.unblockButton.setOnClickListener(this)
+        binding.unblockButton.setOnClickListener { unblock() }
 
     }
-
 }
+    

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsAdapter.kt
@@ -11,16 +11,14 @@ import network.loki.messenger.databinding.BlockedContactLayoutBinding
 import org.session.libsession.utilities.recipients.Recipient
 import org.thoughtcrime.securesms.mms.GlideApp
 
-class BlockedContactsAdapter: ListAdapter<Recipient,BlockedContactsAdapter.ViewHolder>(RecipientDiffer()) {
+class BlockedContactsAdapter(val viewModel: BlockedContactsViewModel) : ListAdapter<Recipient,BlockedContactsAdapter.ViewHolder>(RecipientDiffer()) {
 
     class RecipientDiffer: DiffUtil.ItemCallback<Recipient>() {
         override fun areItemsTheSame(oldItem: Recipient, newItem: Recipient) = oldItem === newItem
         override fun areContentsTheSame(oldItem: Recipient, newItem: Recipient) = oldItem == newItem
     }
 
-    private val selectedItems = mutableListOf<Recipient>()
-
-    fun getSelectedItems() = selectedItems
+    fun getSelectedItems() = viewModel.state.selectedItems
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val itemView = LayoutInflater.from(parent.context).inflate(R.layout.blocked_contact_layout, parent, false)
@@ -28,19 +26,15 @@ class BlockedContactsAdapter: ListAdapter<Recipient,BlockedContactsAdapter.ViewH
     }
 
     private fun toggleSelection(recipient: Recipient, isSelected: Boolean, position: Int) {
-        if (isSelected) {
-            selectedItems -= recipient
-        } else {
-            selectedItems += recipient
-        }
+        viewModel.select(recipient, isSelected)
         notifyItemChanged(position)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val recipient = getItem(position)
-        val isSelected = recipient in selectedItems
+        val isSelected = recipient in viewModel.state.selectedItems
         holder.bind(recipient, isSelected) {
-            toggleSelection(recipient, isSelected, position)
+            toggleSelection(recipient, !isSelected, position)
         }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsAdapter.kt
@@ -28,14 +28,12 @@ class BlockedContactsAdapter(val viewModel: BlockedContactsViewModel) : ListAdap
             .let(::ViewHolder)
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val selectable = getItem(position)
-        holder.bind(selectable, viewModel::toggle)
+        holder.bind(getItem(position), viewModel::toggle)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int, payloads: MutableList<Any>) {
-        val selectable = getItem(position)
-        if (payloads.isEmpty()) holder.bind(selectable, viewModel::toggle)
-        else holder.select(selectable.isSelected)
+        if (payloads.isEmpty()) holder.bind(getItem(position), viewModel::toggle)
+        else holder.select(getItem(position).isSelected)
     }
 
     override fun onViewRecycled(holder: ViewHolder) {

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsAdapter.kt
@@ -18,8 +18,6 @@ class BlockedContactsAdapter(val viewModel: BlockedContactsViewModel) : ListAdap
         override fun areContentsTheSame(oldItem: Recipient, newItem: Recipient) = oldItem == newItem
     }
 
-    fun getSelectedItems() = viewModel.state.selectedItems
-
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         val itemView = LayoutInflater.from(parent.context).inflate(R.layout.blocked_contact_layout, parent, false)
         return ViewHolder(itemView)

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsAdapter.kt
@@ -32,6 +32,12 @@ class BlockedContactsAdapter(val viewModel: BlockedContactsViewModel) : ListAdap
         holder.bind(selectable, viewModel::toggle)
     }
 
+    override fun onBindViewHolder(holder: ViewHolder, position: Int, payloads: MutableList<Any>) {
+        val selectable = getItem(position)
+        if (payloads.isEmpty()) holder.bind(selectable, viewModel::toggle)
+        else holder.select(selectable.isSelected)
+    }
+
     override fun onViewRecycled(holder: ViewHolder) {
         super.onViewRecycled(holder)
         holder.binding.profilePictureView.root.recycle()
@@ -50,6 +56,10 @@ class BlockedContactsAdapter(val viewModel: BlockedContactsViewModel) : ListAdap
             }
             binding.root.setOnClickListener { toggle(selectable) }
             binding.selectButton.isSelected = selectable.isSelected
+        }
+
+        fun select(isSelected: Boolean) {
+            binding.selectButton.isSelected = isSelected
         }
     }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsViewModel.kt
@@ -21,6 +21,7 @@ import network.loki.messenger.R
 import org.session.libsession.utilities.recipients.Recipient
 import org.thoughtcrime.securesms.database.DatabaseContentProviders
 import org.thoughtcrime.securesms.database.Storage
+import org.thoughtcrime.securesms.util.adapter.SelectableItem
 import javax.inject.Inject
 
 @HiltViewModel
@@ -101,10 +102,19 @@ class BlockedContactsViewModel @Inject constructor(private val storage: Storage)
        return context.getString(R.string.Unblock_dialog__message, stringBuilder.toString())
     }
 
+    fun toggle(selectable: SelectableItem<Recipient>) {
+        _state.value = state.run {
+            if (selectable.isSelected) copy(selectedItems = selectedItems - selectable.item)
+            else copy(selectedItems = selectedItems + selectable.item)
+        }
+    }
+
     data class BlockedContactsViewState(
         val blockedContacts: List<Recipient>,
         val selectedItems: Set<Recipient>
     ) {
+        val items = blockedContacts.map { SelectableItem(it, it in selectedItems) }
+
         val isEmpty get() = blockedContacts.isEmpty()
         val unblockButtonEnabled get() = selectedItems.isNotEmpty()
         val emptyStateMessageTextViewVisible get() = blockedContacts.isEmpty()

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
+import network.loki.messenger.R
 import org.session.libsession.utilities.recipients.Recipient
 import org.thoughtcrime.securesms.database.DatabaseContentProviders
 import org.thoughtcrime.securesms.database.Storage
@@ -29,7 +30,9 @@ class BlockedContactsViewModel @Inject constructor(private val storage: Storage)
 
     private val listUpdateChannel = Channel<Unit>(capacity = Channel.CONFLATED)
 
-    private val _contacts = MutableLiveData(BlockedContactsViewState(emptyList()))
+    private val _state = MutableLiveData(BlockedContactsViewState(emptyList(), emptySet()))
+
+    val state get() = _state.value!!
 
     fun subscribe(context: Context): LiveData<BlockedContactsViewState> {
         executor.launch(IO) {
@@ -45,21 +48,66 @@ class BlockedContactsViewModel @Inject constructor(private val storage: Storage)
         }
         executor.launch(IO) {
             for (update in listUpdateChannel) {
-                val blockedContactState = BlockedContactsViewState(storage.blockedContacts().sortedBy { it.name })
+                val blockedContactState = state.copy(
+                    blockedContacts = storage.blockedContacts().sortedBy { it.name }
+                )
                 withContext(Main) {
-                    _contacts.value = blockedContactState
+                    _state.value = blockedContactState
                 }
             }
         }
-        return _contacts
+        return _state
     }
 
-    fun unblock(toUnblock: List<Recipient>) {
-        storage.unblock(toUnblock)
+    fun unblock() {
+        storage.unblock(state.selectedItems)
+        _state.value = state.copy(selectedItems = emptySet())
+    }
+
+    fun select(selectedItem: Recipient, isSelected: Boolean) {
+        _state.value = state.run {
+            if (isSelected) copy(selectedItems = selectedItems + selectedItem)
+            else copy(selectedItems = selectedItems - selectedItem)
+        }
+    }
+
+    fun getTitle(context: Context): String =
+        if (state.selectedItems.size == 1) {
+            context.getString(R.string.Unblock_dialog__title_single, state.selectedItems.first().name)
+        } else {
+            context.getString(R.string.Unblock_dialog__title_multiple)
+        }
+
+    fun getMessage(context: Context): String {
+        if (state.selectedItems.size == 1) {
+            return context.getString(R.string.Unblock_dialog__message, state.selectedItems.first().name)
+        }
+        val stringBuilder = StringBuilder()
+        val iterator = state.selectedItems.iterator()
+        var numberAdded = 0
+        while (iterator.hasNext() && numberAdded < 3) {
+            val nextRecipient = iterator.next()
+            if (numberAdded > 0) stringBuilder.append(", ")
+
+            stringBuilder.append(nextRecipient.name)
+            numberAdded++
+        }
+        val overflow = state.selectedItems.size - numberAdded
+        if (overflow > 0) {
+            stringBuilder.append(" ")
+            val string = context.resources.getQuantityString(R.plurals.Unblock_dialog__message_multiple_overflow, overflow)
+            stringBuilder.append(string.format(overflow))
+        }
+       return context.getString(R.string.Unblock_dialog__message, stringBuilder.toString())
     }
 
     data class BlockedContactsViewState(
-        val blockedContacts: List<Recipient>
-    )
-
+        val blockedContacts: List<Recipient>,
+        val selectedItems: Set<Recipient>
+    ) {
+        val isEmpty get() = blockedContacts.isEmpty()
+        val unblockButtonEnabled get() = selectedItems.isNotEmpty()
+        val emptyStateMessageTextViewVisible get() = blockedContacts.isEmpty()
+        val nonEmptyStateGroupVisible get() = blockedContacts.isNotEmpty()
+    }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsViewModel.kt
@@ -104,7 +104,7 @@ class BlockedContactsViewModel @Inject constructor(private val storage: Storage)
 
     fun toggle(selectable: SelectableItem<Recipient>) {
         _state.value = state.run {
-            if (selectable.isSelected) copy(selectedItems = selectedItems - selectable.item)
+            if (selectable.item in selectedItems) copy(selectedItems = selectedItems - selectable.item)
             else copy(selectedItems = selectedItems + selectable.item)
         }
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsViewModel.kt
@@ -31,7 +31,7 @@ class BlockedContactsViewModel @Inject constructor(private val storage: Storage)
 
     private val listUpdateChannel = Channel<Unit>(capacity = Channel.CONFLATED)
 
-    private val _state = MutableLiveData(BlockedContactsViewState(emptyList(), emptySet()))
+    private val _state = MutableLiveData(BlockedContactsViewState())
 
     val state get() = _state.value!!
 
@@ -110,12 +110,11 @@ class BlockedContactsViewModel @Inject constructor(private val storage: Storage)
     }
 
     data class BlockedContactsViewState(
-        val blockedContacts: List<Recipient>,
-        val selectedItems: Set<Recipient>
+        val blockedContacts: List<Recipient> = emptyList(),
+        val selectedItems: Set<Recipient> = emptySet()
     ) {
         val items = blockedContacts.map { SelectableItem(it, it in selectedItems) }
 
-        val isEmpty get() = blockedContacts.isEmpty()
         val unblockButtonEnabled get() = selectedItems.isNotEmpty()
         val emptyStateMessageTextViewVisible get() = blockedContacts.isEmpty()
         val nonEmptyStateGroupVisible get() = blockedContacts.isNotEmpty()

--- a/app/src/main/java/org/thoughtcrime/securesms/util/adapter/SelectableItem.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/adapter/SelectableItem.kt
@@ -1,0 +1,3 @@
+package org.thoughtcrime.securesms.util.adapter
+
+data class SelectableItem<T>(val item: T, val isSelected: Boolean)

--- a/app/src/main/res/color/button_destructive.xml
+++ b/app/src/main/res/color/button_destructive.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="?android:textColorTertiary"/>
+    <item android:color="@color/destructive"/>
+</selector>

--- a/app/src/main/res/drawable/destructive_outline_button_medium_background.xml
+++ b/app/src/main/res/drawable/destructive_outline_button_medium_background.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-
-    <solid  android:color="@color/transparent" />
-
-    <corners android:radius="@dimen/medium_button_corner_radius" />
-
-    <stroke android:width="@dimen/border_thickness" android:color="@color/button_destructive" />
-</shape>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="@color/button_destructive">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="?colorPrimary"/>
+            <corners android:radius="@dimen/medium_button_corner_radius" />
+            <stroke
+                android:color="@color/button_destructive"
+                android:width="@dimen/border_thickness" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/drawable/destructive_outline_button_medium_background.xml
+++ b/app/src/main/res/drawable/destructive_outline_button_medium_background.xml
@@ -7,5 +7,5 @@
 
     <corners android:radius="@dimen/medium_button_corner_radius" />
 
-    <stroke android:width="@dimen/border_thickness" android:color="@color/destructive" />
+    <stroke android:width="@dimen/border_thickness" android:color="@color/button_destructive" />
 </shape>

--- a/app/src/main/res/drawable/prominent_outline_button_medium_background.xml
+++ b/app/src/main/res/drawable/prominent_outline_button_medium_background.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle">
-
-    <solid  android:color="@color/transparent" />
-
-    <corners android:radius="@dimen/medium_button_corner_radius" />
-
-    <stroke android:width="@dimen/border_thickness" android:color="?prominentButtonColor" />
-</shape>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?prominentButtonColor">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="?colorPrimary"/>
+            <corners android:radius="@dimen/medium_button_corner_radius" />
+            <stroke
+                android:color="?prominentButtonColor"
+                android:width="@dimen/border_thickness" />
+        </shape>
+    </item>
+</ripple>

--- a/app/src/main/res/layout/activity_blocked_contacts.xml
+++ b/app/src/main/res/layout/activity_blocked_contacts.xml
@@ -4,28 +4,37 @@
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerView"
+    <androidx.cardview.widget.CardView
+        android:id="@+id/cardView"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@+id/unblockButton"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:background="@drawable/preference_single_no_padding"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:cardCornerRadius="?preferenceCornerRadius"
+        app:cardElevation="0dp"
+        app:cardBackgroundColor="?colorSettingsBackground"
         android:layout_marginHorizontal="@dimen/medium_spacing"
         android:layout_marginVertical="@dimen/large_spacing"
-        />
+        android:layout_width="match_parent"
+        android:layout_height="0dp">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            />
+
+    </androidx.cardview.widget.CardView>
+
 
     <TextView
         android:id="@+id/emptyStateMessageTextView"
         android:visibility="gone"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toTopOf="@+id/recyclerView"
+        app:layout_constraintTop_toTopOf="@+id/cardView"
         android:layout_marginTop="@dimen/medium_spacing"
-        app:layout_constraintStart_toStartOf="@+id/recyclerView"
-        app:layout_constraintEnd_toEndOf="@+id/recyclerView"
+        app:layout_constraintStart_toStartOf="@+id/cardView"
+        app:layout_constraintEnd_toEndOf="@+id/cardView"
         android:text="@string/blocked_contacts_empty_state"
         />
 
@@ -38,7 +47,7 @@
         android:layout_height="wrap_content"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/recyclerView"
+        app:layout_constraintTop_toBottomOf="@+id/cardView"
         android:id="@+id/unblockButton"
         app:layout_constraintBottom_toBottomOf="parent"
         android:layout_marginVertical="@dimen/large_spacing"
@@ -49,6 +58,6 @@
         android:id="@+id/nonEmptyStateGroup"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:constraint_referenced_ids="unblockButton,recyclerView"/>
+        app:constraint_referenced_ids="unblockButton,cardView"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/blocked_contact_layout.xml
+++ b/app/src/main/res/layout/blocked_contact_layout.xml
@@ -7,6 +7,7 @@
     android:paddingHorizontal="@dimen/medium_spacing"
     android:paddingVertical="@dimen/small_spacing"
     android:gravity="center_vertical"
+    android:background="?selectableItemBackground"
     android:id="@+id/backgroundContainer">
     <include layout="@layout/view_profile_picture"
         android:id="@+id/profilePictureView"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -113,7 +113,7 @@
 
     <style name="Widget.Session.Button.Common.DestructiveOutline">
         <item name="android:background">@drawable/destructive_outline_button_medium_background</item>
-        <item name="android:textColor">@color/destructive</item>
+        <item name="android:textColor">@color/button_destructive</item>
         <item name="android:drawableTint" tools:ignore="NewApi">?android:textColorPrimary</item>
     </style>
 

--- a/libsession/src/main/java/org/session/libsession/database/StorageProtocol.kt
+++ b/libsession/src/main/java/org/session/libsession/database/StorageProtocol.kt
@@ -202,6 +202,6 @@ interface StorageProtocol {
     fun removeReaction(emoji: String, messageTimestamp: Long, author: String, notifyUnread: Boolean)
     fun updateReactionIfNeeded(message: Message, sender: String, openGroupSentTimestamp: Long)
     fun deleteReactions(messageId: Long, mms: Boolean)
-    fun unblock(toUnblock: List<Recipient>)
+    fun unblock(toUnblock: Iterable<Recipient>)
     fun blockedContacts(): List<Recipient>
 }


### PR DESCRIPTION
This PR adds a new disabled state to `Widget.Session.Button.Common.DestructiveOutline` and utilises it in `BlockedContactsActivity` when no recipients are selected.

This PR also:

1.  adds a ripple downstate to that button and `Widget.Session.Button.Common.ProminentOutline` as these buttons often appear together.

2.  utilises `CardView` to mask the items of the list so they don't spill over the rounded corners of their parent.

3. fixes a minor logic error, where the adapter would hold onto selected recipients after they were unblocked.

[device-2023-05-22-222403.webm](https://github.com/oxen-io/session-android/assets/9282178/de34fab6-e8e7-4a97-b859-f76e81ccafe5)

![Screenshot_20230519_172011](https://github.com/oxen-io/session-android/assets/9282178/b1770fa2-7c4c-4179-a478-134b0e5a05fc)
![Screenshot_20230519_171041](https://github.com/oxen-io/session-android/assets/9282178/07722bfa-e279-472b-a534-a1cd45be403e)