### PR TITLE
Fix radio button selection transition

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/ClearAllDataDialog.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/ClearAllDataDialog.kt
@@ -42,6 +42,7 @@ class ClearAllDataDialog : BaseDialog() {
         var selectedOption = device
         val optionAdapter = RadioOptionAdapter { selectedOption = it }
         binding.recyclerView.apply {
+            itemAnimator = null
             adapter = optionAdapter
             addItemDecoration(DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL))
             setHasFixedSize(true)

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/RadioOptionAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/RadioOptionAdapter.kt
@@ -16,8 +16,8 @@ class RadioOptionAdapter(
 ) : ListAdapter<RadioOption, RadioOptionAdapter.ViewHolder>(RadioOptionDiffer()) {
 
     class RadioOptionDiffer: DiffUtil.ItemCallback<RadioOption>() {
-        override fun areItemsTheSame(oldItem: RadioOption, newItem: RadioOption) = oldItem === newItem
-        override fun areContentsTheSame(oldItem: RadioOption, newItem: RadioOption) = oldItem == newItem
+        override fun areItemsTheSame(oldItem: RadioOption, newItem: RadioOption) = oldItem.title == newItem.title
+        override fun areContentsTheSame(oldItem: RadioOption, newItem: RadioOption) = oldItem.value == newItem.value
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
@@ -31,7 +31,7 @@ class RadioOptionAdapter(
         holder.bind(option, isSelected) {
             onClickListener(it)
             selectedOptionPosition = position
-            notifyDataSetChanged()
+            notifyItemRangeChanged(0, itemCount)
         }
     }
 


### PR DESCRIPTION
This PR removes `notifyDataSetChanged` which was causing all items to be recreated in 

`itemAnimator` would cause a fade animation.

`RadioOptionDiffer` is not used, but required by `ListAdapter` and was updated to be more correct.

[device-2023-05-23-120043.webm](https://github.com/oxen-io/session-android/assets/9282178/294593b3-3c11-43ef-bd10-c28962726d29)
