### PR TITLE
Fix TabLayout ripple

### DIFF
--- a/app/src/main/res/layout/activity_join_public_chat.xml
+++ b/app/src/main/res/layout/activity_join_public_chat.xml
@@ -11,7 +11,6 @@
         android:layout_height="match_parent" >
 
         <com.google.android.material.tabs.TabLayout
-            style="@style/Widget.Session.TabLayout"
             android:id="@+id/tabLayout"
             android:layout_width="match_parent"
             android:layout_height="@dimen/tab_bar_height" />

--- a/app/src/main/res/layout/activity_link_device.xml
+++ b/app/src/main/res/layout/activity_link_device.xml
@@ -12,7 +12,6 @@
         android:layout_height="match_parent" >
 
         <com.google.android.material.tabs.TabLayout
-            style="@style/Widget.Session.TabLayout"
             android:id="@+id/tabLayout"
             android:layout_width="match_parent"
             android:layout_height="@dimen/tab_bar_height" />

--- a/app/src/main/res/layout/activity_qr_code.xml
+++ b/app/src/main/res/layout/activity_qr_code.xml
@@ -6,7 +6,6 @@
     android:layout_height="match_parent" >
 
     <com.google.android.material.tabs.TabLayout
-        style="@style/Widget.Session.TabLayout"
         android:id="@+id/tabLayout"
         android:layout_width="match_parent"
         android:layout_height="@dimen/tab_bar_height" />

--- a/app/src/main/res/layout/fragment_join_community.xml
+++ b/app/src/main/res/layout/fragment_join_community.xml
@@ -47,7 +47,6 @@
 
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/tabLayout"
-        style="@style/Widget.Session.TabLayout"
         android:layout_width="match_parent"
         android:layout_height="@dimen/tab_bar_height"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/fragment_new_message.xml
+++ b/app/src/main/res/layout/fragment_new_message.xml
@@ -48,7 +48,6 @@
 
     <com.google.android.material.tabs.TabLayout
         android:id="@+id/tabLayout"
-        style="@style/Widget.Session.TabLayout"
         android:layout_width="match_parent"
         android:layout_height="@dimen/tab_bar_height"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/giphy_activity.xml
+++ b/app/src/main/res/layout/giphy_activity.xml
@@ -28,7 +28,6 @@
                     android:id="@+id/tab_layout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:theme="@style/Widget.Session.TabLayout"
                     app:tabRippleColor="@color/cell_selected"
                     app:tabIndicatorColor="?colorAccent"
                     android:scrollbars="horizontal"/>

--- a/app/src/main/res/layout/media_overview_activity.xml
+++ b/app/src/main/res/layout/media_overview_activity.xml
@@ -21,7 +21,6 @@
 
         <org.thoughtcrime.securesms.components.ControllableTabLayout
                 android:id="@+id/tab_layout"
-                style="@style/Widget.Session.TabLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="top"/>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -56,7 +56,6 @@
         <item name="elevation">1dp</item>
         <item name="tabIndicatorColor">@color/transparent</item>
         <item name="tabIndicatorHeight">@dimen/accent_line_thickness</item>
-        <item name="tabRippleColor">@color/cell_selected</item>
         <item name="tabTextAppearance">@style/TextAppearance.Session.Tab</item>
     </style>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -303,6 +303,8 @@
         <item name="dividerHorizontal">?dividerVertical</item>
         <item name="message_received_background_color">#F2F2F2</item>
         <item name="colorAccent">@color/classic_accent</item>
+        <item name="colorControlHighlight">?android:colorControlHighlight</item>
+        <item name="tabStyle">@style/Widget.Session.TabLayout</item>
     </style>
 
     <style name="Ocean">
@@ -310,6 +312,8 @@
         <item name="dividerHorizontal">?dividerVertical</item>
         <item name="message_received_background_color">#F2F2F2</item>
         <item name="colorAccent">@color/ocean_accent</item>
+        <item name="colorControlHighlight">?android:colorControlHighlight</item>
+        <item name="tabStyle">@style/Widget.Session.TabLayout</item>
     </style>
 
     <style name="Classic.Dark">


### PR DESCRIPTION
This PR improves the downstate of `TabLayout` by setting `colorControlHighlight` to `android:colorControlHighlight` and using that as the ripple/downstate for the tablayout.

This PR assigns the `tablayout` style in the main themes and removes explicit assignments throughout the codebase.

[device-2023-05-23-140709.webm](https://github.com/oxen-io/session-android/assets/9282178/ecc38134-5efd-4964-83cd-8876c2f6b81a)
