### PR TITLE
Improve notification content dialog

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/ListPreferenceDialog.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/ListPreferenceDialog.kt
@@ -4,9 +4,7 @@ import android.content.Context
 import android.view.LayoutInflater
 import androidx.appcompat.app.AlertDialog
 import androidx.preference.ListPreference
-import androidx.recyclerview.widget.DividerItemDecoration
 import network.loki.messenger.databinding.DialogListPreferenceBinding
-import org.thoughtcrime.securesms.conversation.v2.utilities.BaseDialog
 
 fun listPreferenceDialog(
     context: Context,
@@ -20,25 +18,23 @@ fun listPreferenceDialog(
     binding.titleTextView.text = listPreference.dialogTitle
     binding.messageTextView.text = listPreference.dialogMessage
 
-    val options = listPreference.entryValues.zip(listPreference.entries) { value, title ->
-        RadioOption(value.toString(), title.toString())
-    }
-    val valueIndex = listPreference.findIndexOfValue(listPreference.value)
     builder.setView(binding.root)
 
     val dialog = builder.show()
 
-    val optionAdapter = RadioOptionAdapter(valueIndex) {
+    val valueIndex = listPreference.findIndexOfValue(listPreference.value)
+    RadioOptionAdapter(valueIndex) {
         listPreference.value = it.value
         dialog.dismiss()
         dialogListener()
-    }.apply { submitList(options) }
-
-    binding.recyclerView.apply {
-        adapter = optionAdapter
-        addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
-        setHasFixedSize(true)
     }
+        .apply {
+            listPreference.entryValues.zip(listPreference.entries) { value, title ->
+                RadioOption(value.toString(), title.toString())
+            }.let(this::submitList)
+        }
+        .let { binding.recyclerView.adapter = it }
+
     binding.closeButton.setOnClickListener { dialog.dismiss() }
 
     return dialog

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/ListPreferenceDialog.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/ListPreferenceDialog.kt
@@ -1,5 +1,6 @@
 package org.thoughtcrime.securesms.preferences
 
+import android.content.Context
 import android.view.LayoutInflater
 import androidx.appcompat.app.AlertDialog
 import androidx.preference.ListPreference
@@ -7,36 +8,38 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import network.loki.messenger.databinding.DialogListPreferenceBinding
 import org.thoughtcrime.securesms.conversation.v2.utilities.BaseDialog
 
-class ListPreferenceDialog(
-    private val listPreference: ListPreference,
-    private val dialogListener: () -> Unit
-) : BaseDialog() {
-    private lateinit var binding: DialogListPreferenceBinding
+fun listPreferenceDialog(
+    context: Context,
+    listPreference: ListPreference,
+    dialogListener: () -> Unit
+) : AlertDialog {
 
-    override fun setContentView(builder: AlertDialog.Builder) {
-        binding = DialogListPreferenceBinding.inflate(LayoutInflater.from(requireContext()))
-        binding.titleTextView.text = listPreference.dialogTitle
-        binding.messageTextView.text = listPreference.dialogMessage
-        binding.closeButton.setOnClickListener {
-            dismiss()
-        }
-        val options = listPreference.entryValues.zip(listPreference.entries) { value, title ->
-            RadioOption(value.toString(), title.toString())
-        }
-        val valueIndex = listPreference.findIndexOfValue(listPreference.value)
-        val optionAdapter = RadioOptionAdapter(valueIndex) {
-            listPreference.value = it.value
-            dismiss()
-            dialogListener.invoke()
-        }
-        binding.recyclerView.apply {
-            adapter = optionAdapter
-            addItemDecoration(DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL))
-            setHasFixedSize(true)
-        }
-        optionAdapter.submitList(options)
-        builder.setView(binding.root)
-        builder.setCancelable(false)
+    val builder = AlertDialog.Builder(context)
+
+    val binding = DialogListPreferenceBinding.inflate(LayoutInflater.from(context))
+    binding.titleTextView.text = listPreference.dialogTitle
+    binding.messageTextView.text = listPreference.dialogMessage
+
+    val options = listPreference.entryValues.zip(listPreference.entries) { value, title ->
+        RadioOption(value.toString(), title.toString())
     }
+    val valueIndex = listPreference.findIndexOfValue(listPreference.value)
+    builder.setView(binding.root)
 
+    val dialog = builder.show()
+
+    val optionAdapter = RadioOptionAdapter(valueIndex) {
+        listPreference.value = it.value
+        dialog.dismiss()
+        dialogListener()
+    }.apply { submitList(options) }
+
+    binding.recyclerView.apply {
+        adapter = optionAdapter
+        addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
+        setHasFixedSize(true)
+    }
+    binding.closeButton.setOnClickListener { dialog.dismiss() }
+
+    return dialog
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.java
@@ -2,6 +2,8 @@ package org.thoughtcrime.securesms.preferences;
 
 import static android.app.Activity.RESULT_OK;
 
+import static org.thoughtcrime.securesms.preferences.ListPreferenceDialogKt.listPreferenceDialog;
+
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
@@ -77,10 +79,10 @@ public class NotificationsPreferenceFragment extends ListSummaryPreferenceFragme
         .setOnPreferenceClickListener(preference -> {
           ListPreference listPreference = (ListPreference) preference;
           listPreference.setDialogMessage(R.string.preferences_notifications__content_message);
-          new ListPreferenceDialog(listPreference, () -> {
-              initializeListSummary((ListPreference) findPreference(TextSecurePreferences.NOTIFICATION_PRIVACY_PREF));
+          listPreferenceDialog(getContext(), listPreference, () -> {
+              initializeListSummary(findPreference(TextSecurePreferences.NOTIFICATION_PRIVACY_PREF));
               return null;
-          }).show(getChildFragmentManager(), "ListPreferenceDialog");
+          });
           return true;
         });
 

--- a/app/src/main/res/layout/dialog_list_preference.xml
+++ b/app/src/main/res/layout/dialog_list_preference.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="?dialog_background_color">
+    android:layout_height="match_parent">
 
     <TextView
         android:id="@+id/titleTextView"
@@ -21,11 +20,10 @@
 
     <ImageView
         android:id="@+id/closeButton"
+        android:background="?selectableItemBackgroundBorderless"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/medium_spacing"
-        android:clickable="true"
-        android:focusable="true"
         android:src="@drawable/ic_baseline_close_24"
         app:layout_constraintBottom_toBottomOf="@id/titleTextView"
         app:layout_constraintEnd_toEndOf="parent"
@@ -36,7 +34,6 @@
         android:id="@+id/messageTextView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?dialog_background_color"
         android:drawablePadding="@dimen/large_spacing"
         android:gravity="center_horizontal|center_vertical"
         android:paddingHorizontal="@dimen/large_spacing"


### PR DESCRIPTION
This PR utilises `AlertDialog` for the Notification Content Dialog improving the UX by darkening the background and adding rounded corners.

It looks like this:

![Screenshot_20230523_172759](https://github.com/oxen-io/session-android/assets/9282178/90b408c1-c496-4abc-9b68-0d8a4295f1e6)