### PR TITLE
Fix dialog button style

### DIFF
--- a/app/src/main/res/layout/dialog_blocked.xml
+++ b/app/src/main/res/layout/dialog_blocked.xml
@@ -35,7 +35,7 @@
         android:orientation="horizontal">
 
         <Button
-            style="@style/Widget.Session.Button.Dialog.Unimportant"
+            style="@style/Widget.Session.Button.Dialog.UnimportantText"
             android:id="@+id/cancelButton"
             android:layout_width="0dp"
             android:layout_height="@dimen/small_button_height"
@@ -43,7 +43,7 @@
             android:text="@string/cancel" />
 
         <Button
-            style="@style/Widget.Session.Button.Dialog.Unimportant"
+            style="@style/Widget.Session.Button.Dialog.UnimportantText"
             android:id="@+id/unblockButton"
             android:contentDescription="@string/AccessibilityId_block_confirm"
             android:layout_width="0dp"

--- a/app/src/main/res/layout/dialog_download.xml
+++ b/app/src/main/res/layout/dialog_download.xml
@@ -35,7 +35,7 @@
         android:orientation="horizontal">
 
         <Button
-            style="@style/Widget.Session.Button.Dialog.Unimportant"
+            style="@style/Widget.Session.Button.Dialog.UnimportantText"
             android:id="@+id/cancelButton"
             android:layout_width="0dp"
             android:layout_height="@dimen/small_button_height"
@@ -44,7 +44,7 @@
             android:text="@string/cancel" />
 
         <Button
-            style="@style/Widget.Session.Button.Dialog.Unimportant"
+            style="@style/Widget.Session.Button.Dialog.UnimportantText"
             android:id="@+id/downloadButton"
             android:layout_width="0dp"
             android:layout_height="@dimen/small_button_height"

--- a/app/src/main/res/layout/dialog_join_open_group.xml
+++ b/app/src/main/res/layout/dialog_join_open_group.xml
@@ -35,7 +35,7 @@
         android:orientation="horizontal">
 
         <Button
-            style="@style/Widget.Session.Button.Dialog.Unimportant"
+            style="@style/Widget.Session.Button.Dialog.UnimportantText"
             android:id="@+id/cancelButton"
             android:layout_width="0dp"
             android:layout_height="@dimen/small_button_height"
@@ -43,7 +43,7 @@
             android:text="@string/cancel" />
 
         <Button
-            style="@style/Widget.Session.Button.Dialog.Unimportant"
+            style="@style/Widget.Session.Button.Dialog.UnimportantText"
             android:id="@+id/joinButton"
             android:layout_width="0dp"
             android:layout_height="@dimen/small_button_height"

--- a/app/src/main/res/layout/dialog_link_preview.xml
+++ b/app/src/main/res/layout/dialog_link_preview.xml
@@ -35,7 +35,7 @@
         android:orientation="horizontal">
 
         <Button
-            style="@style/Widget.Session.Button.Dialog.Unimportant"
+            style="@style/Widget.Session.Button.Dialog.UnimportantText"
             android:id="@+id/cancelButton"
             android:layout_width="0dp"
             android:layout_height="@dimen/small_button_height"
@@ -44,7 +44,7 @@
             android:contentDescription="@string/AccessibilityId_cancel_link_preview_button"/>
 
         <Button
-            style="@style/Widget.Session.Button.Dialog.Unimportant"
+            style="@style/Widget.Session.Button.Dialog.UnimportantText"
             android:id="@+id/enableLinkPreviewsButton"
             android:layout_width="0dp"
             android:layout_height="@dimen/small_button_height"

--- a/app/src/main/res/layout/dialog_open_url.xml
+++ b/app/src/main/res/layout/dialog_open_url.xml
@@ -35,7 +35,7 @@
         android:orientation="horizontal">
 
         <Button
-            style="@style/Widget.Session.Button.Dialog.Unimportant"
+            style="@style/Widget.Session.Button.Dialog.UnimportantText"
             android:id="@+id/cancelButton"
             android:layout_width="0dp"
             android:layout_height="@dimen/small_button_height"
@@ -43,7 +43,7 @@
             android:text="@string/cancel" />
 
         <Button
-            style="@style/Widget.Session.Button.Dialog.Unimportant"
+            style="@style/Widget.Session.Button.Dialog.UnimportantText"
             android:id="@+id/openURLButton"
             android:layout_width="0dp"
             android:layout_height="@dimen/small_button_height"

--- a/app/src/main/res/layout/dialog_send_seed.xml
+++ b/app/src/main/res/layout/dialog_send_seed.xml
@@ -35,7 +35,7 @@
         android:orientation="horizontal">
 
         <Button
-            style="@style/Widget.Session.Button.Dialog.Unimportant"
+            style="@style/Widget.Session.Button.Dialog.UnimportantText"
             android:id="@+id/cancelButton"
             android:layout_width="0dp"
             android:layout_height="@dimen/small_button_height"
@@ -43,7 +43,7 @@
             android:text="@string/cancel" />
 
         <Button
-            style="@style/Widget.Session.Button.Dialog.Destructive"
+            style="@style/Widget.Session.Button.Dialog.DestructiveText"
             android:id="@+id/sendSeedButton"
             android:layout_width="0dp"
             android:layout_height="@dimen/small_button_height"

--- a/app/src/main/res/layout/dialog_share_logs.xml
+++ b/app/src/main/res/layout/dialog_share_logs.xml
@@ -33,7 +33,7 @@
         android:orientation="horizontal">
 
         <Button
-            style="@style/Widget.Session.Button.Dialog.Unimportant"
+            style="@style/Widget.Session.Button.Dialog.UnimportantText"
             android:id="@+id/cancelButton"
             android:layout_width="0dp"
             android:layout_height="@dimen/small_button_height"
@@ -41,7 +41,7 @@
             android:text="@string/cancel" />
 
         <Button
-            style="@style/Widget.Session.Button.Dialog.Unimportant"
+            style="@style/Widget.Session.Button.Dialog.UnimportantText"
             android:id="@+id/shareButton"
             android:layout_width="0dp"
             android:layout_height="@dimen/small_button_height"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -123,19 +123,10 @@
         <item name="android:textColor">?android:textColorPrimary</item>
     </style>
 
-    <style name="Widget.Session.Button.Dialog.Unimportant">
-        <item name="android:background">@drawable/unimportant_dialog_button_background</item>
-    </style>
-
     <style name="Widget.Session.Button.Dialog.UnimportantText">
         <item name="android:background">@drawable/unimportant_dialog_text_button_background</item>
     </style>
-
-    <style name="Widget.Session.Button.Dialog.Destructive">
-        <item name="android:background">@drawable/destructive_dialog_button_background</item>
-        <item name="android:textColor">@color/black</item>
-    </style>
-
+    
     <style name="Widget.Session.Button.Dialog.DestructiveText">
         <item name="android:background">@drawable/destructive_dialog_text_button_background</item>
         <item name="android:textColor">@color/destructive</item>


### PR DESCRIPTION
Previously we were using `.Unimportant` in a number of places, which was a bordered button. Now these are replaced with `.UnimportantText` and dialogs are much more consistent.

<img width="400" alt="Screen Shot 2023-05-23 at 9 40 11 pm" src="https://github.com/oxen-io/session-android/assets/9282178/9b43e9fc-eae7-4267-8820-3186ed867daf">
