### PR TITLE
Truncate session id when displayed as username

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsActivity.kt
@@ -73,7 +73,7 @@ class SettingsActivity : PassphraseRequiredActionBarActivity() {
         super.onCreate(savedInstanceState, isReady)
         binding = ActivitySettingsBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        val displayName = TextSecurePreferences.getProfileName(this) ?: hexEncodedPublicKey
+        val displayName = getDisplayName()
         glide = GlideApp.with(this)
         with(binding) {
             setupProfilePictureView(profilePictureView.root)
@@ -98,10 +98,16 @@ class SettingsActivity : PassphraseRequiredActionBarActivity() {
         }
     }
 
+    private fun getDisplayName(): String =
+        TextSecurePreferences.getProfileName(this) ?: truncate(hexEncodedPublicKey)
+
+    private fun truncate(key: String): String =
+        key.takeIf { it.length > 8 } ?: "${key.take(4)}…${key.takeLast(4)}"
+
     private fun setupProfilePictureView(view: ProfilePictureView) {
         view.glide = glide
         view.publicKey = hexEncodedPublicKey
-        view.displayName = TextSecurePreferences.getProfileName(this) ?: hexEncodedPublicKey
+        view.displayName = getDisplayName()
         view.isLarge = true
         view.update()
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsActivity.kt
@@ -26,11 +26,8 @@ import nl.komponents.kovenant.all
 import nl.komponents.kovenant.ui.alwaysUi
 import nl.komponents.kovenant.ui.successUi
 import org.session.libsession.avatars.AvatarHelper
-import org.session.libsession.utilities.Address
-import org.session.libsession.utilities.ProfileKeyUtil
-import org.session.libsession.utilities.ProfilePictureUtilities
+import org.session.libsession.utilities.*
 import org.session.libsession.utilities.SSKEnvironment.ProfileManagerProtocol
-import org.session.libsession.utilities.TextSecurePreferences
 import org.thoughtcrime.securesms.PassphraseRequiredActionBarActivity
 import org.thoughtcrime.securesms.avatar.AvatarSelection
 import org.thoughtcrime.securesms.components.ProfilePictureView
@@ -99,10 +96,7 @@ class SettingsActivity : PassphraseRequiredActionBarActivity() {
     }
 
     private fun getDisplayName(): String =
-        TextSecurePreferences.getProfileName(this) ?: truncate(hexEncodedPublicKey)
-
-    private fun truncate(key: String): String =
-        key.takeIf { it.length > 8 } ?: "${key.take(4)}…${key.takeLast(4)}"
+        TextSecurePreferences.getProfileName(this) ?: truncateIdForDisplay(hexEncodedPublicKey)
 
     private fun setupProfilePictureView(view: ProfilePictureView) {
         view.glide = glide

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -131,14 +131,11 @@
         <item name="android:background">@drawable/unimportant_dialog_text_button_background</item>
     </style>
 
-<<<<<<< Updated upstream
     <style name="Widget.Session.Button.Dialog.Destructive">
         <item name="android:background">@drawable/destructive_dialog_button_background</item>
         <item name="android:textColor">@color/black</item>
     </style>
 
-=======
->>>>>>> Stashed changes
     <style name="Widget.Session.Button.Dialog.DestructiveText">
         <item name="android:background">@drawable/destructive_dialog_text_button_background</item>
         <item name="android:textColor">@color/destructive</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -131,11 +131,14 @@
         <item name="android:background">@drawable/unimportant_dialog_text_button_background</item>
     </style>
 
+<<<<<<< Updated upstream
     <style name="Widget.Session.Button.Dialog.Destructive">
         <item name="android:background">@drawable/destructive_dialog_button_background</item>
         <item name="android:textColor">@color/black</item>
     </style>
 
+=======
+>>>>>>> Stashed changes
     <style name="Widget.Session.Button.Dialog.DestructiveText">
         <item name="android:background">@drawable/destructive_dialog_text_button_background</item>
         <item name="android:textColor">@color/destructive</item>

--- a/libsession/src/main/java/org/session/libsession/messaging/utilities/UpdateMessageBuilder.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/utilities/UpdateMessageBuilder.kt
@@ -10,13 +10,13 @@ import org.session.libsession.utilities.ExpirationUtil
 
 object UpdateMessageBuilder {
 
-    fun buildGroupUpdateMessage(context: Context, updateMessageData: UpdateMessageData, sender: String? = null, isOutgoing: Boolean = false): String {
+    fun buildGroupUpdateMessage(context: Context, updateMessageData: UpdateMessageData, senderId: String? = null, isOutgoing: Boolean = false): String {
         var message = ""
         val updateData = updateMessageData.kind ?: return message
-        if (!isOutgoing && sender == null) return message
+        if (!isOutgoing && senderId == null) return message
         val storage = MessagingModuleConfiguration.shared.storage
         val senderName: String = if (!isOutgoing) {
-            storage.getContactWithSessionID(sender!!)?.displayName(Contact.ContactContext.REGULAR) ?: sender
+            storage.getContactWithSessionID(senderId!!)?.displayName(Contact.ContactContext.REGULAR) ?: truncate(senderId)
         } else { context.getString(R.string.MessageRecord_you) }
 
         when (updateData) {
@@ -77,11 +77,11 @@ object UpdateMessageBuilder {
         return message
     }
 
-    fun buildExpirationTimerMessage(context: Context, duration: Long, sender: String? = null, isOutgoing: Boolean = false): String {
-        if (!isOutgoing && sender == null) return ""
+    fun buildExpirationTimerMessage(context: Context, duration: Long, senderId: String? = null, isOutgoing: Boolean = false): String {
+        if (!isOutgoing && senderId == null) return ""
         val storage = MessagingModuleConfiguration.shared.storage
         val senderName: String? = if (!isOutgoing) {
-            storage.getContactWithSessionID(sender!!)?.displayName(Contact.ContactContext.REGULAR) ?: sender
+            storage.getContactWithSessionID(senderId!!)?.displayName(Contact.ContactContext.REGULAR) ?: truncate(senderId)
         } else { context.getString(R.string.MessageRecord_you) }
         return if (duration <= 0) {
             if (isOutgoing) context.getString(R.string.MessageRecord_you_disabled_disappearing_messages)
@@ -93,9 +93,9 @@ object UpdateMessageBuilder {
         }
     }
 
-    fun buildDataExtractionMessage(context: Context, kind: DataExtractionNotificationInfoMessage.Kind, sender: String? = null): String {
+    fun buildDataExtractionMessage(context: Context, kind: DataExtractionNotificationInfoMessage.Kind, senderId: String? = null): String {
         val storage = MessagingModuleConfiguration.shared.storage
-        val senderName = storage.getContactWithSessionID(sender!!)?.displayName(Contact.ContactContext.REGULAR) ?: sender!!
+        val senderName = storage.getContactWithSessionID(senderId!!)?.displayName(Contact.ContactContext.REGULAR) ?: truncate(senderId)
         return when (kind) {
             DataExtractionNotificationInfoMessage.Kind.SCREENSHOT ->
                 context.getString(R.string.MessageRecord_s_took_a_screenshot, senderName)
@@ -119,3 +119,6 @@ object UpdateMessageBuilder {
         }
     }
 }
+
+private fun truncate(id: String): String =
+    id.takeIf { it.length > 8 }?.apply{ "${take(4)}...${takeLast(4)}" } ?: id

--- a/libsession/src/main/java/org/session/libsession/messaging/utilities/UpdateMessageBuilder.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/utilities/UpdateMessageBuilder.kt
@@ -7,6 +7,7 @@ import org.session.libsession.messaging.calls.CallMessageType
 import org.session.libsession.messaging.contacts.Contact
 import org.session.libsession.messaging.sending_receiving.data_extraction.DataExtractionNotificationInfoMessage
 import org.session.libsession.utilities.ExpirationUtil
+import org.session.libsession.utilities.truncateIdForDisplay
 
 object UpdateMessageBuilder {
 
@@ -16,7 +17,7 @@ object UpdateMessageBuilder {
         if (!isOutgoing && senderId == null) return message
         val storage = MessagingModuleConfiguration.shared.storage
         val senderName: String = if (!isOutgoing) {
-            storage.getContactWithSessionID(senderId!!)?.displayName(Contact.ContactContext.REGULAR) ?: truncate(senderId)
+            storage.getContactWithSessionID(senderId!!)?.displayName(Contact.ContactContext.REGULAR) ?: truncateIdForDisplay(senderId)
         } else { context.getString(R.string.MessageRecord_you) }
 
         when (updateData) {
@@ -81,7 +82,7 @@ object UpdateMessageBuilder {
         if (!isOutgoing && senderId == null) return ""
         val storage = MessagingModuleConfiguration.shared.storage
         val senderName: String? = if (!isOutgoing) {
-            storage.getContactWithSessionID(senderId!!)?.displayName(Contact.ContactContext.REGULAR) ?: truncate(senderId)
+            storage.getContactWithSessionID(senderId!!)?.displayName(Contact.ContactContext.REGULAR) ?: truncateIdForDisplay(senderId)
         } else { context.getString(R.string.MessageRecord_you) }
         return if (duration <= 0) {
             if (isOutgoing) context.getString(R.string.MessageRecord_you_disabled_disappearing_messages)
@@ -95,7 +96,7 @@ object UpdateMessageBuilder {
 
     fun buildDataExtractionMessage(context: Context, kind: DataExtractionNotificationInfoMessage.Kind, senderId: String? = null): String {
         val storage = MessagingModuleConfiguration.shared.storage
-        val senderName = storage.getContactWithSessionID(senderId!!)?.displayName(Contact.ContactContext.REGULAR) ?: truncate(senderId)
+        val senderName = storage.getContactWithSessionID(senderId!!)?.displayName(Contact.ContactContext.REGULAR) ?: truncateIdForDisplay(senderId)
         return when (kind) {
             DataExtractionNotificationInfoMessage.Kind.SCREENSHOT ->
                 context.getString(R.string.MessageRecord_s_took_a_screenshot, senderName)
@@ -119,6 +120,3 @@ object UpdateMessageBuilder {
         }
     }
 }
-
-private fun truncate(id: String): String =
-    id.takeIf { it.length > 8 }?.apply{ "${take(4)}...${takeLast(4)}" } ?: id

--- a/libsession/src/main/java/org/session/libsession/utilities/IdUtil.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/IdUtil.kt
@@ -1,0 +1,4 @@
+package org.session.libsession.utilities
+
+fun truncateIdForDisplay(id: String): String =
+    id.takeIf { it.length > 8 }?.apply{ "${take(4)}…${takeLast(4)}" } ?: id


### PR DESCRIPTION
This PR truncates ids to the first and last 4 chars delimited by an ellipsis when username is null.