### PR TITLE
Fix scroll to bottom button visibility

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -211,8 +211,6 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
 
     private var emojiPickerVisible = false
 
-    private val canScroll: Boolean
-        get() = binding?.conversationRecyclerView?.computeVerticalScrollOffset()?.let { it >= 0 } ?: false
     private val isScrolledToBottom: Boolean
         get() = binding?.conversationRecyclerView?.isScrolledToBottom ?: true
 
@@ -917,7 +915,7 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
     }
 
     private fun showScrollToBottomButtonIfApplicable() {
-        binding?.scrollToBottomButton?.isVisible = !emojiPickerVisible && !isScrolledToBottom && canScroll && adapter.itemCount > 0
+        binding?.scrollToBottomButton?.isVisible = !emojiPickerVisible && !isScrolledToBottom && adapter.itemCount > 0
     }
 
     private fun updateUnreadCountIndicator() {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -21,7 +21,6 @@ import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.annotation.DimenRes
 import androidx.appcompat.app.AlertDialog
-import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -210,6 +209,10 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
     val searchViewModel: SearchViewModel by viewModels()
     var searchViewItem: MenuItem? = null
 
+    private var emojiPickerVisible = false
+
+    private val canScroll: Boolean
+        get() = binding?.conversationRecyclerView?.computeVerticalScrollOffset()?.let { it >= 0 } ?: false
     private val isScrolledToBottom: Boolean
         get() = binding?.conversationRecyclerView?.isScrolledToBottom ?: true
 
@@ -441,17 +444,22 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
                 handleRecyclerViewScrolled()
             }
         })
+
+        binding!!.conversationRecyclerView.addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+            showScrollToBottomButtonIfApplicable()
+        }
     }
 
     // called from onCreate
     private fun setUpToolBar() {
-        setSupportActionBar(binding?.toolbar)
+        val binding = binding ?: return
+        setSupportActionBar(binding.toolbar)
         val actionBar = supportActionBar ?: return
         val recipient = viewModel.recipient ?: return
         actionBar.title = ""
         actionBar.setDisplayHomeAsUpEnabled(true)
         actionBar.setHomeButtonEnabled(true)
-        binding!!.toolbarContent.conversationTitleView.text = when {
+        binding.toolbarContent.conversationTitleView.text = when {
             recipient.isLocalNumber -> getString(R.string.note_to_self)
             else -> recipient.toShortString()
         }
@@ -461,13 +469,11 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
             R.dimen.small_profile_picture_size
         }
         val size = resources.getDimension(sizeID).roundToInt()
-        binding!!.toolbarContent.profilePictureView.root.layoutParams = LinearLayout.LayoutParams(size, size)
-        binding!!.toolbarContent.profilePictureView.root.glide = glide
+        binding.toolbarContent.profilePictureView.root.layoutParams = LinearLayout.LayoutParams(size, size)
+        binding.toolbarContent.profilePictureView.root.glide = glide
         MentionManagerUtilities.populateUserPublicKeyCacheIfNeeded(viewModel.threadId, this)
-        val profilePictureView = binding!!.toolbarContent.profilePictureView.root
-        viewModel.recipient?.let { recipient ->
-            profilePictureView.update(recipient)
-        }
+        val profilePictureView = binding.toolbarContent.profilePictureView.root
+        viewModel.recipient?.let(profilePictureView::update)
     }
 
     // called from onCreate
@@ -904,15 +910,14 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
         val binding = binding ?: return
         val wasTypingIndicatorVisibleBefore = binding.typingIndicatorViewContainer.isVisible
         binding.typingIndicatorViewContainer.isVisible = wasTypingIndicatorVisibleBefore && isScrolledToBottom
-        binding.typingIndicatorViewContainer.isVisible
-        showOrHidScrollToBottomButton()
+        showScrollToBottomButtonIfApplicable()
         val firstVisiblePosition = layoutManager?.findFirstVisibleItemPosition() ?: -1
         unreadCount = min(unreadCount, firstVisiblePosition).coerceAtLeast(0)
         updateUnreadCountIndicator()
     }
 
-    private fun showOrHidScrollToBottomButton(show: Boolean = true) {
-        binding?.scrollToBottomButton?.isVisible = show && !isScrolledToBottom && adapter.itemCount > 0
+    private fun showScrollToBottomButtonIfApplicable() {
+        binding?.scrollToBottomButton?.isVisible = !emojiPickerVisible && !isScrolledToBottom && canScroll && adapter.itemCount > 0
     }
 
     private fun updateUnreadCountIndicator() {
@@ -1084,21 +1089,26 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
             Log.e("Loki", "Failed to show emoji picker", e)
             return
         }
+
+        val binding = binding ?: return
+
+        emojiPickerVisible = true
         ViewUtil.hideKeyboard(this, visibleMessageView)
-        binding?.reactionsShade?.isVisible = true
-        showOrHidScrollToBottomButton(false)
-        binding?.conversationRecyclerView?.suppressLayout(true)
+        binding.reactionsShade.isVisible = true
+        binding.scrollToBottomButton.isVisible = false
+        binding.conversationRecyclerView.suppressLayout(true)
         reactionDelegate.setOnActionSelectedListener(ReactionsToolbarListener(message))
         reactionDelegate.setOnHideListener(object: ConversationReactionOverlay.OnHideListener {
             override fun startHide() {
-                binding?.reactionsShade?.let {
+                emojiPickerVisible = false
+                binding.reactionsShade.let {
                     ViewUtil.fadeOut(it, resources.getInteger(R.integer.reaction_scrubber_hide_duration), View.GONE)
                 }
-                showOrHidScrollToBottomButton(true)
+                showScrollToBottomButtonIfApplicable()
             }
 
             override fun onHide() {
-                binding?.conversationRecyclerView?.suppressLayout(false)
+                binding.conversationRecyclerView.suppressLayout(false)
 
                 WindowUtil.setLightStatusBarFromTheme(this@ConversationActivityV2);
                 WindowUtil.setLightNavigationBarFromTheme(this@ConversationActivityV2);

--- a/libsession/src/main/java/org/session/libsession/utilities/ViewUtils.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/ViewUtils.kt
@@ -5,6 +5,7 @@ import android.util.TypedValue
 import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
 import androidx.recyclerview.widget.RecyclerView
+import kotlin.math.max
 
 @ColorInt
 fun Context.getColorFromAttr(
@@ -17,4 +18,4 @@ fun Context.getColorFromAttr(
 }
 
 val RecyclerView.isScrolledToBottom: Boolean
-    get() = computeVerticalScrollOffset() + computeVerticalScrollExtent() >= computeVerticalScrollRange()
+    get() = max(0, computeVerticalScrollOffset()) + computeVerticalScrollExtent() >= computeVerticalScrollRange()


### PR DESCRIPTION
There were a few issues.

1. Because we sometimes use `reverseOrder` in the `RecyclerView`, items are at the bottom of the RecyclerView, so I had to constrain `offset` with `max(0, offset)`.
2. When we have the keyboard open and then we long press a message the keyboard will be hidden. We need to hide the button when the `emojiPicker` is visible. But `handleRecyclerViewScrolled` was being called changing the visibility. So this PR adds an `emojiPickerVisible` field to make sure they are not shown together.

[device-2023-05-25-154412.webm](https://github.com/oxen-io/session-android/assets/9282178/b8f0536f-8a15-400c-b5bb-dee6bd972cc9)
