### PR TITLE
[SES-540] Add 50dp to isScrolledToBottom

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/GeneralUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/GeneralUtilities.kt
@@ -3,6 +3,8 @@ package org.thoughtcrime.securesms.util
 import android.content.res.Resources
 import android.os.Build
 import androidx.annotation.ColorRes
+import androidx.recyclerview.widget.RecyclerView
+import kotlin.math.max
 import kotlin.math.roundToInt
 
 fun Resources.getColorWithID(@ColorRes id: Int, theme: Resources.Theme?): Int {
@@ -30,3 +32,8 @@ fun toDp(px: Float, resources: Resources): Float {
     val scale = resources.displayMetrics.density
     return (px / scale)
 }
+
+val RecyclerView.isScrolledToBottom: Boolean
+    get() = computeVerticalScrollOffset().coerceAtLeast(0) +
+            computeVerticalScrollExtent() +
+            toPx(50, resources) >= computeVerticalScrollRange()

--- a/libsession/src/main/java/org/session/libsession/utilities/ViewUtils.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/ViewUtils.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.util.TypedValue
 import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
-import androidx.recyclerview.widget.RecyclerView
-import kotlin.math.max
 
 @ColorInt
 fun Context.getColorFromAttr(
@@ -16,6 +14,3 @@ fun Context.getColorFromAttr(
     theme.resolveAttribute(attrColor, typedValue, resolveRefs)
     return typedValue.data
 }
-
-val RecyclerView.isScrolledToBottom: Boolean
-    get() = max(0, computeVerticalScrollOffset()) + computeVerticalScrollExtent() >= computeVerticalScrollRange()


### PR DESCRIPTION
This PR improves the UX by hiding the scroll to bottom button when you are less than 50dp away from the bottom.