### PR TITLE
Fix back button background in light themes

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -303,7 +303,6 @@
         <item name="dividerHorizontal">?dividerVertical</item>
         <item name="message_received_background_color">#F2F2F2</item>
         <item name="colorAccent">@color/classic_accent</item>
-        <item name="colorControlHighlight">?android:colorControlHighlight</item>
         <item name="tabStyle">@style/Widget.Session.TabLayout</item>
     </style>
 
@@ -312,7 +311,6 @@
         <item name="dividerHorizontal">?dividerVertical</item>
         <item name="message_received_background_color">#F2F2F2</item>
         <item name="colorAccent">@color/ocean_accent</item>
-        <item name="colorControlHighlight">?android:colorControlHighlight</item>
         <item name="tabStyle">@style/Widget.Session.TabLayout</item>
     </style>
 
@@ -338,6 +336,7 @@
         <item name="colorSettingsBackground">@color/classic_dark_1</item>
         <item name="colorDividerBackground">@color/classic_dark_3</item>
         <item name="android:colorControlHighlight">@color/classic_dark_3</item>
+        <item name="colorControlHighlight">@color/classic_dark_3</item>
         <item name="actionBarPopupTheme">@style/Dark.Popup</item>
         <item name="actionBarWidgetTheme">@null</item>
         <item name="actionBarTheme">@style/ThemeOverlay.AppCompat.Dark.ActionBar</item>
@@ -410,6 +409,7 @@
         <item name="colorSettingsBackground">@color/classic_light_5</item>
         <item name="colorDividerBackground">@color/classic_light_3</item>
         <item name="android:colorControlHighlight">@color/classic_light_3</item>
+        <item name="colorControlHighlight">@color/classic_light_3</item>
         <item name="bottomSheetDialogTheme">@style/Classic.Light.BottomSheet</item>
         <item name="android:actionMenuTextColor">?android:textColorPrimary</item>
         <item name="popupTheme">?actionBarPopupTheme</item>
@@ -496,6 +496,7 @@
         <item name="colorSettingsBackground">@color/ocean_dark_1</item>
         <item name="colorDividerBackground">@color/ocean_dark_4</item>
         <item name="android:colorControlHighlight">@color/ocean_dark_4</item>
+        <item name="colorControlHighlight">@color/ocean_dark_4</item>
         <item name="bottomSheetDialogTheme">@style/Ocean.Dark.BottomSheet</item>
         <item name="popupTheme">?actionBarPopupTheme</item>
         <item name="actionMenuTextColor">?android:textColorPrimary</item>
@@ -576,6 +577,7 @@
         <item name="colorSettingsBackground">@color/ocean_light_6</item>
         <item name="colorDividerBackground">@color/ocean_light_3</item>
         <item name="android:colorControlHighlight">@color/ocean_light_4</item>
+        <item name="colorControlHighlight">@color/ocean_light_4</item>
         <item name="bottomSheetDialogTheme">@style/Ocean.Light.BottomSheet</item>
         <item name="actionBarPopupTheme">@style/Light.Popup</item>
         <item name="popupTheme">?actionBarPopupTheme</item>


### PR DESCRIPTION
It turns out `<item name="colorControlHighlight">?android:colorControlHighlight</item>` wasn't working as I thought it would. so this PR sets it explicitly in each theme.