### PR TITLE
Fix debug screen security default

### DIFF
--- a/app/src/main/res/xml/preferences_app_protection.xml
+++ b/app/src/main/res/xml/preferences_app_protection.xml
@@ -14,7 +14,7 @@
 
         <!-- TODO: check figure out what is needed for this -->
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
-            android:defaultValue="true"
+            android:defaultValue="@bool/screen_security_default"
             android:key="pref_screen_security"
             android:title="@string/preferences__screen_security"
             android:summary="@string/preferences__disable_screen_security_to_allow_screen_shots" />

--- a/libsession/src/debug/res/values/values.xml
+++ b/libsession/src/debug/res/values/values.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="screen_security_default">false</bool>
+</resources>

--- a/libsession/src/main/java/org/session/libsession/utilities/TextSecurePreferences.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/TextSecurePreferences.kt
@@ -649,7 +649,7 @@ interface TextSecurePreferences {
 
         @JvmStatic
         fun isScreenSecurityEnabled(context: Context): Boolean {
-            return getBooleanPreference(context, SCREEN_SECURITY_PREF, !BuildConfig.DEBUG)
+            return getBooleanPreference(context, SCREEN_SECURITY_PREF, context.resources.getBoolean(R.bool.screen_security_default))
         }
 
         fun getLastVersionCode(context: Context): Int {

--- a/libsession/src/main/res/values/values.xml
+++ b/libsession/src/main/res/values/values.xml
@@ -2,4 +2,5 @@
 <resources>
     <bool name="enable_alarm_manager">true</bool>
     <bool name="enable_job_service">false</bool>
+    <bool name="screen_security_default">true</bool>
 </resources>


### PR DESCRIPTION
`defaultValue` will persist to `SharedPreferences` when it is inflated. So I'm setting the default in `values` and making that the source of truth for the default value for this preference.