### PR TITLE
[SES-205] Fix message clipping

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
@@ -9,9 +9,11 @@ import android.graphics.drawable.ColorDrawable
 import android.os.Handler
 import android.os.Looper
 import android.util.AttributeSet
+import android.view.Gravity
 import android.view.HapticFeedbackConstants
 import android.view.MotionEvent
 import android.view.View
+import android.widget.FrameLayout
 import android.widget.LinearLayout
 import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
@@ -114,6 +116,7 @@ class VisibleMessageView : LinearLayout {
         binding.root.disableClipping()
         binding.mainContainer.disableClipping()
         binding.messageInnerContainer.disableClipping()
+        binding.messageInnerLayout.disableClipping()
         binding.messageContentView.root.disableClipping()
     }
     // endregion
@@ -342,11 +345,14 @@ class VisibleMessageView : LinearLayout {
 
     private fun updateExpirationTimer(message: MessageRecord) {
         val container = binding.messageInnerContainer
-        val content = binding.messageContentView.root
-        val expiration = binding.expirationTimerView
-        container.removeAllViewsInLayout()
-        container.addView(if (message.isOutgoing) expiration else content)
-        container.addView(if (message.isOutgoing) content else expiration)
+        val layout = binding.messageInnerLayout
+
+        if (message.isOutgoing) binding.messageContentView.root.bringToFront()
+        else binding.expirationTimerView.bringToFront()
+
+        layout.layoutParams = layout.layoutParams.let { it as FrameLayout.LayoutParams }
+            .apply { gravity = if (message.isOutgoing) Gravity.END else Gravity.START }
+
         val containerParams = container.layoutParams as ConstraintLayout.LayoutParams
         containerParams.horizontalBias = if (message.isOutgoing) 1f else 0f
         container.layoutParams = containerParams

--- a/app/src/main/res/layout/view_visible_message.xml
+++ b/app/src/main/res/layout/view_visible_message.xml
@@ -107,35 +107,40 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:text="@tools:sample/full_names" />
 
-        <LinearLayout
+        <FrameLayout
             android:id="@+id/messageInnerContainer"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
             app:layout_constraintBottom_toBottomOf="@+id/profilePictureView"
             app:layout_constraintStart_toEndOf="@+id/profilePictureView"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/senderNameTextView">
 
-            <include layout="@layout/view_visible_message_content"
-                android:id="@+id/messageContentView"
-                android:layout_width="0dp"
+            <LinearLayout
+                android:id="@+id/messageInnerLayout"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"/>
+                android:orientation="horizontal">
 
-            <org.thoughtcrime.securesms.conversation.v2.components.ExpirationTimerView
-                android:id="@+id/expirationTimerView"
-                android:layout_width="12dp"
-                android:layout_height="12dp"
-                android:layout_gravity="center_vertical"
-                android:layout_marginHorizontal="@dimen/small_spacing"
-                android:contentDescription="@string/AccessibilityId_timer_icon"
-                android:visibility="invisible"
-                tools:visibility="visible"
-                tools:src="@drawable/timer60"
-                tools:tint="@color/black"/>
+                <include layout="@layout/view_visible_message_content"
+                    android:id="@+id/messageContentView"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content" />
 
-        </LinearLayout>
+                <org.thoughtcrime.securesms.conversation.v2.components.ExpirationTimerView
+                    android:id="@+id/expirationTimerView"
+                    android:layout_width="12dp"
+                    android:layout_height="12dp"
+                    android:layout_gravity="center_vertical"
+                    android:layout_marginHorizontal="@dimen/small_spacing"
+                    android:contentDescription="@string/AccessibilityId_timer_icon"
+                    android:visibility="invisible"
+                    tools:visibility="visible"
+                    tools:src="@drawable/timer60"
+                    tools:tint="@color/black"/>
+
+            </LinearLayout>
+        </FrameLayout>
 
         <include layout="@layout/view_emoji_reactions"
             android:id="@+id/emojiReactionsView"


### PR DESCRIPTION
using `layout_weight` on `messageContentView` doesn't work well when it is drawn to bitmap as the bitmap will contain a lot of empty space causing it to be cut off.  It also pushes the timestamp to the edge.

<img width="389" alt="Screen Shot 2023-07-18 at 1 40 04 pm" src="https://github.com/oxen-io/session-android/assets/9282178/5ebe0627-2aed-44f0-bf62-111024813a92">

This PR fixes the issue by

1.  removing `weight` from `messageContentView` and setting its width to `wrap_content`
2. wrapping messageInnerLayout with a `FrameLayout` as the `margin_end` on `profile pic` was not respected unless `profile && messageInnerContainer` were chained.  But when it was chained bias on `messageInnerLayout` was not respected, so views would not appear in the correct places. So this FrameLayout allows us to place child layout at the start or end and allows us to hold the margin here.