### PR TITLE
[SES-206, SES-359] Enable reply with voice and fix layout

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -1606,7 +1606,12 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
         return Pair(recipient.address, sentTimestamp)
     }
 
-    private fun sendAttachments(attachments: List<Attachment>, body: String?, quotedMessage: MessageRecord? = null, linkPreview: LinkPreview? = null): Pair<Address, Long>? {
+    private fun sendAttachments(
+        attachments: List<Attachment>,
+        body: String?,
+        quotedMessage: MessageRecord? = binding?.inputBar?.quote,
+        linkPreview: LinkPreview? = null
+    ): Pair<Address, Long>? {
         val recipient = viewModel.recipient ?: return null
         val sentTimestamp = SnodeAPI.nowWithOffset
         processMessageRequestApproval()

--- a/app/src/main/res/layout/view_visible_message_content.xml
+++ b/app/src/main/res/layout/view_visible_message_content.xml
@@ -36,15 +36,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"/>
 
-        <include layout="@layout/view_voice_message"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            android:visibility="gone"
-            android:id="@+id/voiceMessageView"
-            android:layout_width="160dp"
-            android:layout_height="36dp"/>
-
         <include layout="@layout/view_open_group_invitation"
             tools:visibility="gone"
             app:layout_constraintTop_toTopOf="parent"
@@ -74,6 +65,15 @@
             android:id="@+id/quoteView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"/>
+
+        <include layout="@layout/view_voice_message"
+            app:layout_constraintTop_toBottomOf="@id/quoteView"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:visibility="gone"
+            android:id="@+id/voiceMessageView"
+            android:layout_width="160dp"
+            android:layout_height="36dp"/>
 
         <include layout="@layout/view_link_preview"
             app:layout_constraintTop_toBottomOf="@+id/quoteView"


### PR DESCRIPTION
<img width="252" alt="Screen Shot 2023-07-20 at 1 19 12 pm" src="https://github.com/oxen-io/session-android/assets/9282178/fffac50c-6d76-47b9-9c7c-8ef5ddadc9cb">

...

<img width="176" alt="Screen Shot 2023-07-20 at 1 20 21 pm" src="https://github.com/oxen-io/session-android/assets/9282178/e473e43e-71de-42cc-bbd1-59b37f29f220">
