### PR TITLE
Increase activity_home_outdated_client_config text size to 11sp

### DIFF
--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -110,7 +110,7 @@
                     android:layout_gravity="center"
                     android:textColor="?message_sent_text_color"
                     android:background="?colorAccent"
-                    android:textSize="9sp"
+                    android:textSize="11sp"
                     android:paddingVertical="4dp"
                     android:paddingHorizontal="64dp"
                     android:gravity="center"


### PR DESCRIPTION
Android Studio gives a warning on text that has a size less than `11sp` as it is difficult to read.

### before

<img width="380" alt="Screen Shot 2023-07-31 at 9 32 16 pm" src="https://github.com/oxen-io/session-android/assets/9282178/39c7121e-41cc-4a03-8b66-4d09c0ab5a6b">

### after

<img width="371" alt="Screen Shot 2023-07-31 at 9 38 19 pm" src="https://github.com/oxen-io/session-android/assets/9282178/7d391b34-4ae9-4b2e-b2ac-656b802a50d0">
