### PR TITLE
Use separate keys for huawei shared prefs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -135,6 +135,7 @@ android {
             buildConfigField "boolean", "PLAY_STORE_DISABLED", "false"
             buildConfigField "org.session.libsession.utilities.Device", "DEVICE", "org.session.libsession.utilities.Device.ANDROID"
             buildConfigField "String", "NOPLAY_UPDATE_URL", "$ext.websiteUpdateUrl"
+            buildConfigField 'String', 'PUSH_KEY_SUFFIX', '\"\"'
         }
 
         huawei {
@@ -143,7 +144,7 @@ android {
             buildConfigField "boolean", "PLAY_STORE_DISABLED", "true"
             buildConfigField "org.session.libsession.utilities.Device", "DEVICE", "org.session.libsession.utilities.Device.HUAWEI"
             buildConfigField "String", "NOPLAY_UPDATE_URL", "$ext.websiteUpdateUrl"
-
+            buildConfigField 'String', 'PUSH_KEY_SUFFIX', '\"_HUAWEI\"'
         }
 
         website {
@@ -152,6 +153,7 @@ android {
             buildConfigField "boolean", "PLAY_STORE_DISABLED", "true"
             buildConfigField "org.session.libsession.utilities.Device", "DEVICE", "org.session.libsession.utilities.Device.ANDROID"
             buildConfigField "String", "NOPLAY_UPDATE_URL", "\"$ext.websiteUpdateUrl\""
+            buildConfigField 'String', 'PUSH_KEY_SUFFIX', '\"\"'
         }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -109,6 +109,7 @@ import dagger.hilt.EntryPoints;
 import dagger.hilt.android.HiltAndroidApp;
 import kotlin.Unit;
 import kotlinx.coroutines.Job;
+import network.loki.messenger.BuildConfig;
 import network.loki.messenger.libsession_util.ConfigBase;
 import network.loki.messenger.libsession_util.UserProfile;
 
@@ -206,6 +207,8 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
 
     @Override
     public void onCreate() {
+        TextSecurePreferences.setPushSuffix(BuildConfig.PUSH_KEY_SUFFIX);
+
         DatabaseModule.init(this);
         MessagingModuleConfiguration.configure(this);
         super.onCreate();

--- a/libsession/src/main/java/org/session/libsession/utilities/TextSecurePreferences.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/TextSecurePreferences.kt
@@ -189,6 +189,9 @@ interface TextSecurePreferences {
         internal val _events = MutableSharedFlow<String>(0, 64, BufferOverflow.DROP_OLDEST)
         val events get() = _events.asSharedFlow()
 
+        @JvmStatic
+        var pushSuffix = ""
+
         const val DISABLE_PASSPHRASE_PREF = "pref_disable_passphrase"
         const val LANGUAGE_PREF = "pref_language"
         const val THREAD_TRIM_NOW = "pref_trim_now"
@@ -251,9 +254,9 @@ interface TextSecurePreferences {
         const val LINK_PREVIEWS = "pref_link_previews"
         const val GIF_METADATA_WARNING = "has_seen_gif_metadata_warning"
         const val GIF_GRID_LAYOUT = "pref_gif_grid_layout"
-        const val IS_PUSH_ENABLED = "pref_is_using_fcm"
-        const val PUSH_TOKEN = "pref_fcm_token_2"
-        const val PUSH_REGISTER_TIME = "pref_last_fcm_token_upload_time_2"
+        val IS_PUSH_ENABLED get() = "pref_is_using_fcm$pushSuffix"
+        val PUSH_TOKEN get() = "pref_fcm_token_2$pushSuffix"
+        val PUSH_REGISTER_TIME get() = "pref_last_fcm_token_upload_time_2$pushSuffix"
         const val LAST_CONFIGURATION_SYNC_TIME = "pref_last_configuration_sync_time"
         const val CONFIGURATION_SYNCED = "pref_configuration_synced"
         const val LAST_PROFILE_UPDATE_TIME = "pref_last_profile_update_time"


### PR DESCRIPTION
This will be useful when a user installs a Huawei build over a Play build (or vice versa) as tokens for each service will not be mixed up.