### PR TITLE
Add huawei build folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ ffpr
 *.sh
 pkcs11.password
 app/play
+app/huawei


### PR DESCRIPTION
prevents built artifacts from showing up as unstaged