### PR TITLE
Make playDebug the default variant

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -122,6 +122,7 @@ android {
             minifyEnabled false
         }
         debug {
+            isDefault true
             minifyEnabled false
         }
     }
@@ -129,6 +130,7 @@ android {
     flavorDimensions "distribution"
     productFlavors {
         play {
+            isDefault true
             dimension "distribution"
             apply plugin: 'com.google.gms.google-services'
             ext.websiteUpdateUrl = "null"


### PR DESCRIPTION
As variants are ordered alphabetically, Huawei is the default variant which could be unexpected and add friction as the `-Phuawei` argument needs to be passed in to gradle.