### PR TITLE
Ignore unknown fields in push V2 json

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/PushReceiver.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/PushReceiver.kt
@@ -10,6 +10,7 @@ import com.goterl.lazysodium.utils.Key
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonBuilder
 import org.session.libsession.messaging.jobs.BatchMessageReceiveJob
 import org.session.libsession.messaging.jobs.JobQueue
 import org.session.libsession.messaging.jobs.MessageReceiveParameters
@@ -28,6 +29,7 @@ private const val TAG = "PushHandler"
 
 class PushReceiver @Inject constructor(@ApplicationContext val context: Context) {
     private val sodium = LazySodiumAndroid(SodiumAndroid())
+    private val json = Json { ignoreUnknownKeys = true }
 
     fun onPush(dataMap: Map<String, String>?) {
         onPush(dataMap?.asByteArray())
@@ -89,7 +91,7 @@ class PushReceiver @Inject constructor(@ApplicationContext val context: Context)
             ?: error("Failed to decode bencoded list from payload")
 
         val metadataJson = (expectedList[0] as? BencodeString)?.value ?: error("no metadata")
-        val metadata: PushNotificationMetadata = Json.decodeFromString(String(metadataJson))
+        val metadata: PushNotificationMetadata = json.decodeFromString(String(metadataJson))
 
         return (expectedList.getOrNull(1) as? BencodeString)?.value.also {
             // null content is valid only if we got a "data_too_long" flag


### PR DESCRIPTION
This PR fixes an issue where push notifications were not showing the message content in the notification drawer.

<img width="342" alt="Screenshot 2023-09-21 at 8 09 45 pm" src="https://github.com/oxen-io/session-android/assets/9282178/b8421d2b-a9bb-431d-903d-2d90ad4a922a">


```
Invalid push notification
    kotlinx.serialization.json.internal.JsonDecodingException: Unexpected JSON token at offset 137: Encountered an unknown key 't' at path: $.n
    Use 'ignoreUnknownKeys = true' in 'Json {}' builder to ignore unknown keys.
    JSON input: {"@": "...", "#": "...", "n": 0, "t": ..., "z": ..., "l": ...}
    at kotlinx.serialization.json.internal.JsonExceptionsKt.JsonDecodingException(JsonExceptions.kt:24)
```

