### PR TITLE
Fixed #1085 | Video call auto rotate, when auto rotate is disabled

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
@@ -21,6 +21,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
+import android.provider.Settings
 import kotlinx.coroutines.launch
 import network.loki.messenger.R
 import network.loki.messenger.databinding.ActivityWebrtcBinding
@@ -99,7 +100,14 @@ class WebRtcCallActivity : PassphraseRequiredActionBarActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?, ready: Boolean) {
         super.onCreate(savedInstanceState, ready)
-        rotationListener.enable()
+
+        // Only enable auto-rotate if system auto-rotate is enabled
+        if (isAutoRotateOn()) {
+            rotationListener.enable()
+        } else {
+            rotationListener.disable()
+        }
+
         binding = ActivityWebrtcBinding.inflate(layoutInflater)
         setContentView(binding.root)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
@@ -181,6 +189,14 @@ class WebRtcCallActivity : PassphraseRequiredActionBarActivity() {
             onBackPressed()
         }
 
+    }
+
+    //Function to check if Android System Auto-rotate is on or off
+    private fun isAutoRotateOn(): Boolean {
+        return Settings.System.getInt(
+            contentResolver,
+            Settings.System.ACCELEROMETER_ROTATION, 0
+        ) == 1
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I was unable to test my contribution
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1085` [syntax](https://github.com/oxen-io/session-android/issues/1085)

----------

### Description
- [Fixes#1085](https://github.com/oxen-io/session-android/issues/1085)
- This fixes the issue the user faces - `Disabling auto rotate in my settings, doesn't disable auto rotate in video calls`
- I was unable to test the issue after fixing it.

----------

I am open to suggestions/comments to improve my contributions. Thanks!
