### PR TITLE
fix: sanitize the query before carrying out the search and trim it fi…

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/search/SearchRepository.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/search/SearchRepository.java
@@ -113,14 +113,16 @@ public class SearchRepository {
   }
 
   public void query(@NonNull String query, long threadId, @NonNull Callback<CursorList<MessageResult>> callback) {
-    if (TextUtils.isEmpty(query)) {
+    String cleanQuery = sanitizeQuery(query);
+
+    if (!isValidQuery(cleanQuery)) {
       callback.onResult(CursorList.emptyList());
       return;
     }
 
     executor.execute(() -> {
       long startTime = System.currentTimeMillis();
-      CursorList<MessageResult> messages = queryMessages(sanitizeQuery(query), threadId);
+      CursorList<MessageResult> messages = queryMessages(cleanQuery, threadId);
       Log.d(TAG, "[ConversationQuery] " + (System.currentTimeMillis() - startTime) + " ms");
 
       callback.onResult(messages);
@@ -218,6 +220,14 @@ public class SearchRepository {
 
     return out.toString();
   }
+
+    private boolean isValidQuery(String query) {
+      if (query.trim().length() == 0) return false;
+
+      if (TextUtils.isEmpty(query)) return false;
+
+      return true;
+    }
 
   private static class ContactModelBuilder implements CursorList.ModelBuilder<Contact> {
 

--- a/app/src/main/java/org/thoughtcrime/securesms/search/SearchRepository.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/search/SearchRepository.java
@@ -115,7 +115,7 @@ public class SearchRepository {
   public void query(@NonNull String query, long threadId, @NonNull Callback<CursorList<MessageResult>> callback) {
     String cleanQuery = sanitizeQuery(query);
 
-    if (!isValidQuery(cleanQuery)) {
+    if (cleanQuery.trim().isEmpty()) {
       callback.onResult(CursorList.emptyList());
       return;
     }
@@ -220,14 +220,6 @@ public class SearchRepository {
 
     return out.toString();
   }
-
-    private boolean isValidQuery(String query) {
-      if (query.trim().length() == 0) return false;
-
-      if (TextUtils.isEmpty(query)) return false;
-
-      return true;
-    }
 
   private static class ContactModelBuilder implements CursorList.ModelBuilder<Contact> {
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have tested my contribution on these devices:
 * Device Galaxy A34, Android 13
 * Virtual Pixel 7 Pro, Android 11
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1346` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Evidence

https://github.com/oxen-io/session-android/assets/31456362/c3ad3f9a-57b9-4142-83ec-f6e0a9c29fbb


### Description
Sanitization was carried out before carrying out the search, as well as validating that the query is not empty or only has empty spaces.

Fix related to this bug (https://github.com/oxen-io/session-android/issues/1346).
