### PR TITLE
Handle expired one-time permission for calls

### DIFF
--- a/libsession/src/main/java/org/session/libsession/utilities/TextSecurePreferences.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/TextSecurePreferences.kt
@@ -167,7 +167,9 @@ interface TextSecurePreferences {
     fun setHasHiddenMessageRequests()
     fun setShownCallWarning(): Boolean
     fun setShownCallNotification(): Boolean
+    fun resetShownCallNotification()
     fun isCallNotificationsEnabled(): Boolean
+    fun setCallNotificationsEnabled(newValue: Boolean)
     fun getLastVacuum(): Long
     fun setLastVacuumNow()
     fun getFingerprintKeyGenerated(): Boolean
@@ -1573,6 +1575,10 @@ class AppTextSecurePreferences @Inject constructor(
         return getBooleanPreference(CALL_NOTIFICATIONS_ENABLED, false)
     }
 
+    override fun setCallNotificationsEnabled(newValue: Boolean) {
+        setBooleanPreference(CALL_NOTIFICATIONS_ENABLED, newValue)
+    }
+
     override fun getLastVacuum(): Long {
         return getLongPreference(LAST_VACUUM_TIME, 0)
     }
@@ -1589,6 +1595,9 @@ class AppTextSecurePreferences @Inject constructor(
         return previousValue != setValue
     }
 
+    override fun resetShownCallNotification() {
+        setBooleanPreference(SHOWN_CALL_NOTIFICATION, false)
+    }
 
     /**
      * Set the SHOWN_CALL_WARNING preference to `true`


### PR DESCRIPTION
Fixes #1378

### Contributor checklist
- [X] I have tested my contribution on these devices:
 * Samsung Galaxy S22, Android 13
 * Emulator, Android 13
- [ ] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description

This PR fixes an issue where a Microphone permission is granted on a one-time basis but is never checked again even after the permission is automatically revoked after the application process is restarted. However, the Privacy Voice and Video Calls permission stays enabled and the user can both initiate and answer the calls but the audio will not work.

This fixes includes:
- check the permission on app start (HomeActivity:onCreate)
- if the permission is not granted any more, the Voice And Video Calls feature will be disabled
- also, the ShownCallNotification will be reset so that the next time a call is attempted the user will see why the call failed

### Future improvements

During the app start the `HomeActivity` uses `Permissions` API which only provides `request(String...)` method of providing permission(s) to obtain. So if the one-time permission has expired a new Permission Dialog will be shown asking the user to grant it (again). If that UX is suboptimal, a new method `check(String...)` can be implemented and the `exectute()` will only check but not ask for  the permission(s) and quietly return `onAllGranted` or `onAnyDenied`.