### PR TITLE
Fixes oxen-io/session-android#704 - Reply state is lost when replying with link preview

### DIFF
--- a/app/src/main/res/layout/view_input_bar.xml
+++ b/app/src/main/res/layout/view_input_bar.xml
@@ -12,8 +12,11 @@
         android:layout_height="1px"
         android:background="@color/separator" />
 
-    <FrameLayout
+    <!-- Additional content layout is a LinearLayout with a vertical split (i.e., it uses rows) to
+    allow multiple Views to exist, specifically both QuoteDraft and LinkPreviewDraft Views -->
+    <LinearLayout
         android:id="@+id/inputBarAdditionalContentContainer"
+        android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have tested my contribution on these devices:
 * Samsung S9+ on Android 9 / API 28
 * Virtual Pixel 3a on Android 14 / API 34
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
This PR fixes the issue that any message could only ever have a quote/reply element (as in when replying to a message the first part of the reply is the quoted first part of the message being replied to) **OR** it could have a URI preview - but it could never have _both_, as adding a URI preview to a message that was a reply removed the quote element, and adding a quote element to a message that had a URI preview removed that preview and replaced it with the quote element.

To perform this fix the 'additional content' layout was modified from a `FrameLayout` (which typically only holds a single child View) to a `LinearLayout` with vertical orientation so that both a quote View and a link-preview View can exist as part of the message and be displayed at the same time (both on the sending and receiving devices). Then, the `InputBar.kt` class was adjusted so that quote and preview Views could co-exist in the layout, and that adding one type of View did not remove the other.

The quote/reply View is _always_ displayed at the top of the message, and may be removed and re-added at will. Additionally, users are are free to add/remove/update a single link preview (generated from the first identified URI in the message) at will.

Users running session-android v1.17.5 can successfully receive and display messages that contain both a quote/reply and a link preview - but they will be unable to respond with their _own_ messages that contains both a quote & a preview because they do not have this patched version of the code yet.

These adjustments were tested by sending multiple messages between users in both standalone mode and as part of a group, and adding/removing reply elements, as well as adding/removing/updating link preview elements both with and without quote/reply elements. To the best of my knowledge the functionality of having both reply/quote and link-preview elements now works as it should.

**Demonstration of a message containing both a reply and a link preview (which looked identical on the receiving device - the Samsung S9+ running stock `session-android` v1.17.5)**:

![Session-Android_Issue_704_Fixed_Example](https://github.com/oxen-io/session-android/assets/8717505/530e8b77-3f14-4ea0-8977-436b4fed109c)