### PR TITLE
SA429 Cannot save generic files

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -1948,6 +1948,14 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
 
     override fun saveAttachment(messages: Set<MessageRecord>) {
         val message = messages.first() as MmsMessageRecord
+
+        // Do not allow the user to download a file attachment before it has finished downloading
+        // TODO: Localise the msg in this toast!
+        if (message.isMediaPending) {
+            Toast.makeText(this, resources.getString(R.string.conversation_activity__wait_until_attachment_has_finished_downloading), Toast.LENGTH_LONG).show()
+            return
+        }
+
         SaveAttachmentTask.showWarningDialog(this) {
             Permissions.with(this)
                 .request(Manifest.permission.WRITE_EXTERNAL_STORAGE)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/DocumentView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/DocumentView.kt
@@ -33,6 +33,7 @@ class DocumentView : LinearLayout {
         binding.documentTitleTextView.setTextColor(textColor)
         binding.documentViewIconImageView.imageTintList = ColorStateList.valueOf(textColor)
 
+        /*
         // Make the icon for the file appear as sending if attachment download is not yet complete
         // Note: The `!message.isRead/isDelivered` clause stops previous messages from changing icon
         // when we/ receive a new message with a non-scheme attachment (like a zip etc.). I have no
@@ -41,7 +42,7 @@ class DocumentView : LinearLayout {
         // should be.
         // TODO: Is this due to a race condition? Ask Harris what he thinks...
         if (message.isMediaPending && !message.isRead && !message.isDelivered) {
-            Log.d("[ACL]", "[DocumentView] Setting `documentViewIconImageView` to look like status pending!")
+            Log.d("[ACL]", "[DocumentView] Setting `documentViewIconImageView` to look like status pending! 12345")
 
             // Create the animation
             var rotateAnimation = RotateAnimation(0f, 360f, Animation.RELATIVE_TO_SELF, 0.5f, Animation.RELATIVE_TO_SELF, 0.5f)
@@ -60,23 +61,25 @@ class DocumentView : LinearLayout {
             binding.documentViewIconImageView.setImageResource(R.drawable.ic_message_details__refresh)
             binding.documentViewIconImageView.startAnimation(rotateAnimation)
         }
+        */
     }
     // endregion
 
     // Class to listen for the end of the download 'rotation' animation and set the document icon
     // back on the message's ImageView.
-    private class RotationAnimationListener(val documentViewIconImageView: ImageView, val originalDrawable: Drawable): AnimationListener {
+    class RotationAnimationListener(private val documentViewIconImageView: ImageView, private val originalDrawable: Drawable): AnimationListener {
         override fun onAnimationStart(animation: Animation?) { /* Do nothing */ }
 
         override fun onAnimationEnd(animation: Animation?) {
             Log.d("[ACL]", "Detected that animation ended - resetting document icon!")
             // Set the document icon back on the ImageView instead of the rotating icon
-            // TODO: Is there a way to get the correct document icon for the user's current theme?
-            //documentViewIconImageView.setImageResource(R.drawable.ic_document_large_light)
+            // Note: `setImageResource` operates on the UI thread which apparently can cause a
+            // "latency hiccup" so `setImageDrawable` is preferred.
+            //documentViewIconImageView.setImageResource(R.drawable.ic_document_large_light) // No!
             documentViewIconImageView.setImageDrawable(originalDrawable)
         }
 
-        override fun onAnimationRepeat(animation: Animation?) {/* Do nothing */ }
+        override fun onAnimationRepeat(animation: Animation?) { /* Do nothing */ }
     }
 
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/DocumentView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/DocumentView.kt
@@ -2,14 +2,24 @@ package org.thoughtcrime.securesms.conversation.v2.messages
 
 import android.content.Context
 import android.content.res.ColorStateList
+import android.graphics.drawable.Drawable
 import android.util.AttributeSet
+import android.view.animation.Animation
+import android.view.animation.Animation.AnimationListener
+import android.view.animation.LinearInterpolator
+import android.view.animation.RotateAnimation
+import android.widget.ImageView
 import android.widget.LinearLayout
 import androidx.annotation.ColorInt
+import network.loki.messenger.R
 import network.loki.messenger.databinding.ViewDocumentBinding
+import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.database.model.MmsMessageRecord
+
 
 class DocumentView : LinearLayout {
     private val binding: ViewDocumentBinding by lazy { ViewDocumentBinding.bind(this) }
+
     // region Lifecycle
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
@@ -22,6 +32,51 @@ class DocumentView : LinearLayout {
         binding.documentTitleTextView.text = document.fileName.or("Untitled File")
         binding.documentTitleTextView.setTextColor(textColor)
         binding.documentViewIconImageView.imageTintList = ColorStateList.valueOf(textColor)
+
+        // Make the icon for the file appear as sending if attachment download is not yet complete
+        // Note: The `!message.isRead/isDelivered` clause stops previous messages from changing icon
+        // when we/ receive a new message with a non-scheme attachment (like a zip etc.). I have no
+        // idea why other files can look as if they have media pending after they've downloaded, but
+        // they can - although going out of the message thread and then back in shows the icons as they
+        // should be.
+        // TODO: Is this due to a race condition? Ask Harris what he thinks...
+        if (message.isMediaPending && !message.isRead && !message.isDelivered) {
+            Log.d("[ACL]", "[DocumentView] Setting `documentViewIconImageView` to look like status pending!")
+
+            // Create the animation
+            var rotateAnimation = RotateAnimation(0f, 360f, Animation.RELATIVE_TO_SELF, 0.5f, Animation.RELATIVE_TO_SELF, 0.5f)
+            rotateAnimation.interpolator = LinearInterpolator()
+            rotateAnimation.repeatCount = Animation.INFINITE
+            rotateAnimation.duration = 1000 // Duration is in milliseconds, so 1000ms is 1 second
+
+            // Set a custom animation listener on our rotate animation so when it stops (which
+            // occurs when the attachment download has completed) we can change the icon back to the
+            // file icon.
+            val rotationAnimationListener = RotationAnimationListener(binding.documentViewIconImageView, binding.documentViewIconImageView.drawable)
+            rotateAnimation.setAnimationListener(rotationAnimationListener)
+
+            // Set the icon image and start the rotation to act like a spinner
+            //binding.documentViewIconImageView.setImageResource(R.drawable.ic_delivery_status_sending)
+            binding.documentViewIconImageView.setImageResource(R.drawable.ic_message_details__refresh)
+            binding.documentViewIconImageView.startAnimation(rotateAnimation)
+        }
     }
     // endregion
+
+    // Class to listen for the end of the download 'rotation' animation and set the document icon
+    // back on the message's ImageView.
+    private class RotationAnimationListener(val documentViewIconImageView: ImageView, val originalDrawable: Drawable): AnimationListener {
+        override fun onAnimationStart(animation: Animation?) { /* Do nothing */ }
+
+        override fun onAnimationEnd(animation: Animation?) {
+            Log.d("[ACL]", "Detected that animation ended - resetting document icon!")
+            // Set the document icon back on the ImageView instead of the rotating icon
+            // TODO: Is there a way to get the correct document icon for the user's current theme?
+            //documentViewIconImageView.setImageResource(R.drawable.ic_document_large_light)
+            documentViewIconImageView.setImageDrawable(originalDrawable)
+        }
+
+        override fun onAnimationRepeat(animation: Animation?) {/* Do nothing */ }
+    }
+
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/DocumentView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/DocumentView.kt
@@ -2,20 +2,11 @@ package org.thoughtcrime.securesms.conversation.v2.messages
 
 import android.content.Context
 import android.content.res.ColorStateList
-import android.graphics.drawable.Drawable
 import android.util.AttributeSet
-import android.view.animation.Animation
-import android.view.animation.Animation.AnimationListener
-import android.view.animation.LinearInterpolator
-import android.view.animation.RotateAnimation
-import android.widget.ImageView
 import android.widget.LinearLayout
 import androidx.annotation.ColorInt
-import network.loki.messenger.R
 import network.loki.messenger.databinding.ViewDocumentBinding
-import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.database.model.MmsMessageRecord
-
 
 class DocumentView : LinearLayout {
     private val binding: ViewDocumentBinding by lazy { ViewDocumentBinding.bind(this) }
@@ -32,54 +23,7 @@ class DocumentView : LinearLayout {
         binding.documentTitleTextView.text = document.fileName.or("Untitled File")
         binding.documentTitleTextView.setTextColor(textColor)
         binding.documentViewIconImageView.imageTintList = ColorStateList.valueOf(textColor)
-
-        /*
-        // Make the icon for the file appear as sending if attachment download is not yet complete
-        // Note: The `!message.isRead/isDelivered` clause stops previous messages from changing icon
-        // when we/ receive a new message with a non-scheme attachment (like a zip etc.). I have no
-        // idea why other files can look as if they have media pending after they've downloaded, but
-        // they can - although going out of the message thread and then back in shows the icons as they
-        // should be.
-        // TODO: Is this due to a race condition? Ask Harris what he thinks...
-        if (message.isMediaPending && !message.isRead && !message.isDelivered) {
-            Log.d("[ACL]", "[DocumentView] Setting `documentViewIconImageView` to look like status pending! 12345")
-
-            // Create the animation
-            var rotateAnimation = RotateAnimation(0f, 360f, Animation.RELATIVE_TO_SELF, 0.5f, Animation.RELATIVE_TO_SELF, 0.5f)
-            rotateAnimation.interpolator = LinearInterpolator()
-            rotateAnimation.repeatCount = Animation.INFINITE
-            rotateAnimation.duration = 1000 // Duration is in milliseconds, so 1000ms is 1 second
-
-            // Set a custom animation listener on our rotate animation so when it stops (which
-            // occurs when the attachment download has completed) we can change the icon back to the
-            // file icon.
-            val rotationAnimationListener = RotationAnimationListener(binding.documentViewIconImageView, binding.documentViewIconImageView.drawable)
-            rotateAnimation.setAnimationListener(rotationAnimationListener)
-
-            // Set the icon image and start the rotation to act like a spinner
-            //binding.documentViewIconImageView.setImageResource(R.drawable.ic_delivery_status_sending)
-            binding.documentViewIconImageView.setImageResource(R.drawable.ic_message_details__refresh)
-            binding.documentViewIconImageView.startAnimation(rotateAnimation)
-        }
-        */
     }
     // endregion
-
-    // Class to listen for the end of the download 'rotation' animation and set the document icon
-    // back on the message's ImageView.
-    class RotationAnimationListener(private val documentViewIconImageView: ImageView, private val originalDrawable: Drawable): AnimationListener {
-        override fun onAnimationStart(animation: Animation?) { /* Do nothing */ }
-
-        override fun onAnimationEnd(animation: Animation?) {
-            Log.d("[ACL]", "Detected that animation ended - resetting document icon!")
-            // Set the document icon back on the ImageView instead of the rotating icon
-            // Note: `setImageResource` operates on the UI thread which apparently can cause a
-            // "latency hiccup" so `setImageDrawable` is preferred.
-            //documentViewIconImageView.setImageResource(R.drawable.ic_document_large_light) // No!
-            documentViewIconImageView.setImageDrawable(originalDrawable)
-        }
-
-        override fun onAnimationRepeat(animation: Animation?) { /* Do nothing */ }
-    }
 
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
@@ -22,6 +22,7 @@ import androidx.core.text.getSpans
 import androidx.core.text.toSpannable
 import androidx.core.view.children
 import androidx.core.view.isVisible
+import com.google.android.material.progressindicator.CircularProgressIndicator
 import network.loki.messenger.R
 import network.loki.messenger.databinding.ViewVisibleMessageContentBinding
 import okhttp3.HttpUrl
@@ -54,8 +55,8 @@ class VisibleMessageContentView : ConstraintLayout {
     var delegate: VisibleMessageViewDelegate? = null
     var indexInAdapter: Int = -1
 
-    var rotationAnimationListener: DocumentView.RotationAnimationListener? = null
-    var rotateAnimation: RotateAnimation? = null
+    //var rotationAnimationListener: DocumentView.RotationAnimationListener? = null
+    //var rotateAnimation: RotateAnimation? = null
 
     // region Lifecycle
     constructor(context: Context) : super(context)
@@ -147,35 +148,6 @@ class VisibleMessageContentView : ConstraintLayout {
                 val attachmentId = dbAttachment.attachmentId.rowId
                 if (attach.transferState == AttachmentTransferProgress.TRANSFER_PROGRESS_PENDING
                     && MessagingModuleConfiguration.shared.storage.getAttachmentUploadJob(attachmentId) == null) {
-
-
-
-
-                    /*
-                    Log.d("[ACL]", "Hit displaySpinnerDuringAttachmentDownload!")
-
-                    // Create the animation that will rotate the spinner image around its center
-                    var rotateAnimation = RotateAnimation(0f, 360f, Animation.RELATIVE_TO_SELF, 0.5f, Animation.RELATIVE_TO_SELF, 0.5f)
-                    rotateAnimation.interpolator = LinearInterpolator()
-                    rotateAnimation.repeatCount = Animation.INFINITE
-                    rotateAnimation.duration = 1000 // Duration is in milliseconds, so 1000ms is 1 second
-
-                    // Set a custom animation listener on our rotate animation so when it stops (which
-                    // occurs when the attachment download has completed) we can change the icon back to the
-                    // file icon.
-                    rotationAnimationListener = DocumentView.RotationAnimationListener(
-                        binding.documentView.documentViewIconImageView,
-                        binding.documentView.documentViewIconImageView.drawable
-                    )
-                    rotateAnimation.setAnimationListener(rotationAnimationListener)
-
-                    // Set the icon image and start the rotation animation
-                    binding.documentView.documentViewIconImageView.setImageResource(R.drawable.ic_message_details__refresh)
-                    binding.documentView.documentViewIconImageView.startAnimation(rotateAnimation)
-                    */
-
-
-
                     onAttachmentNeedsDownload(attachmentId, dbAttachment.mmsId)
                 }
             }
@@ -218,6 +190,12 @@ class VisibleMessageContentView : ConstraintLayout {
                 hideBody = true
                 // Document attachment
                 if (contactIsTrusted || message.isOutgoing) {
+                    // Show the progress spinner if the attachment is downloading, otherwise show
+                    // the document icon (and always remove the other)
+                    binding.documentView.documentViewProgress.visibility      = if (message.isMediaPending) { VISIBLE } else { GONE    }
+                    binding.documentView.documentViewIconImageView.visibility = if (message.isMediaPending) { GONE    } else { VISIBLE }
+                    binding.root.invalidate() // Force layout update
+
                     binding.documentView.root.bind(message, VisibleMessageContentView.getTextColor(context, message))
                 } else {
                     binding.untrustedView.root.bind(UntrustedAttachmentView.AttachmentType.DOCUMENT, VisibleMessageContentView.getTextColor(context,message))
@@ -358,30 +336,4 @@ class VisibleMessageContentView : ConstraintLayout {
     }
     // endregion
 
-    // Function to make the icon for an file attachment that is being downloaded into a spinner for
-    // the duration of the download task.
-    private fun displaySpinnerDuringAttachmentDownload() {
-        Log.d("[ACL]", "Hit displaySpinnerDuringAttachmentDownload!")
-
-        // Create the animation that will rotate the spinner image around its center
-        rotateAnimation = RotateAnimation(0f, 360f, Animation.RELATIVE_TO_SELF, 0.5f, Animation.RELATIVE_TO_SELF, 0.5f).also {
-            it.interpolator = LinearInterpolator()
-            it.repeatCount = Animation.INFINITE
-            it.duration = 1000 // Duration is in milliseconds, so 1000ms is 1 second
-        }
-
-
-        // Set a custom animation listener on our rotate animation so when it stops (which
-        // occurs when the attachment download has completed) we can change the icon back to the
-        // file icon.
-        rotationAnimationListener = DocumentView.RotationAnimationListener(
-            binding.documentView.documentViewIconImageView,
-            binding.documentView.documentViewIconImageView.drawable
-        )
-        rotateAnimation?.setAnimationListener(rotationAnimationListener)
-
-        // Set the icon image and start the rotation animation
-        binding.documentView.documentViewIconImageView.setImageResource(R.drawable.ic_message_details__refresh)
-        binding.documentView.documentViewIconImageView.startAnimation(rotateAnimation)
-    }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
@@ -11,9 +11,6 @@ import android.text.util.Linkify
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
-import android.view.animation.Animation
-import android.view.animation.LinearInterpolator
-import android.view.animation.RotateAnimation
 import androidx.annotation.ColorInt
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -22,7 +19,6 @@ import androidx.core.text.getSpans
 import androidx.core.text.toSpannable
 import androidx.core.view.children
 import androidx.core.view.isVisible
-import com.google.android.material.progressindicator.CircularProgressIndicator
 import network.loki.messenger.R
 import network.loki.messenger.databinding.ViewVisibleMessageContentBinding
 import okhttp3.HttpUrl
@@ -32,7 +28,6 @@ import org.session.libsession.messaging.sending_receiving.attachments.DatabaseAt
 import org.session.libsession.utilities.ThemeUtil
 import org.session.libsession.utilities.getColorFromAttr
 import org.session.libsession.utilities.recipients.Recipient
-import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.conversation.v2.ConversationActivityV2
 import org.thoughtcrime.securesms.conversation.v2.ModalUrlBottomSheet
 import org.thoughtcrime.securesms.conversation.v2.utilities.MentionUtilities
@@ -188,7 +183,7 @@ class VisibleMessageContentView : ConstraintLayout {
                 // Document attachment
                 if (contactIsTrusted || message.isOutgoing) {
                     // Show the progress spinner if the attachment is downloading, otherwise show
-                    // the document icon (and always remove the other)
+                    // the document icon (and always remove the other, whichever one that is)
                     binding.documentView.documentViewProgress.visibility      = if (message.isMediaPending) { VISIBLE } else { GONE    }
                     binding.documentView.documentViewIconImageView.visibility = if (message.isMediaPending) { GONE    } else { VISIBLE }
                     binding.root.invalidate() // Force layout update

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
@@ -55,9 +55,6 @@ class VisibleMessageContentView : ConstraintLayout {
     var delegate: VisibleMessageViewDelegate? = null
     var indexInAdapter: Int = -1
 
-    //var rotationAnimationListener: DocumentView.RotationAnimationListener? = null
-    //var rotateAnimation: RotateAnimation? = null
-
     // region Lifecycle
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet) : super(context, attrs)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
@@ -12,6 +12,9 @@ import android.view.Gravity
 import android.view.HapticFeedbackConstants
 import android.view.MotionEvent
 import android.view.View
+import android.view.animation.Animation
+import android.view.animation.LinearInterpolator
+import android.view.animation.RotateAnimation
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import androidx.annotation.ColorInt
@@ -35,6 +38,7 @@ import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.ViewUtil
 import org.session.libsession.utilities.getColorFromAttr
 import org.session.libsignal.utilities.IdPrefix
+import org.session.libsignal.utilities.Log
 import org.session.libsignal.utilities.ThreadUtils
 import org.thoughtcrime.securesms.ApplicationContext
 import org.thoughtcrime.securesms.conversation.v2.ConversationActivityV2
@@ -63,7 +67,6 @@ import kotlin.math.sqrt
 
 @AndroidEntryPoint
 class VisibleMessageView : LinearLayout {
-
     @Inject lateinit var threadDb: ThreadDatabase
     @Inject lateinit var lokiThreadDb: LokiThreadDatabase
     @Inject lateinit var lokiApiDb: LokiAPIDatabase
@@ -91,6 +94,9 @@ class VisibleMessageView : LinearLayout {
     var onSwipeToReply: (() -> Unit)? = null
     var onLongPress: (() -> Unit)? = null
     val messageContentView: VisibleMessageContentView by lazy { binding.messageContentView.root }
+
+    private var rotateAnimation: RotateAnimation? = null
+    private var rotationAnimationListener: DocumentView.RotationAnimationListener? = null
 
     companion object {
         const val swipeToReplyThreshold = 64.0f // dp
@@ -120,6 +126,8 @@ class VisibleMessageView : LinearLayout {
     }
     // endregion
 
+    var messagesWeHaveBound = mutableListOf<Long>()
+
     // region Updating
     fun bind(
         message: MessageRecord,
@@ -133,6 +141,16 @@ class VisibleMessageView : LinearLayout {
         delegate: VisibleMessageViewDelegate? = null,
         onAttachmentNeedsDownload: (Long, Long) -> Unit
     ) {
+        /*
+        // TODO: Why is this `bind()` call getting hit for each message TWICE IN A ROW?!?!
+        Log.d("[ACL]", "Hit VisibleMessageView.bind() on message with id: ${message.id}")
+        if (message.id in messagesWeHaveBound) {
+            Log.d("[ACL]", "Already bound message ${message.id} - bailing!")
+            return
+        }
+        messagesWeHaveBound.add(message.id)
+        */
+
         val threadID = message.threadId
         val thread = threadDb.getRecipientForThreadId(threadID) ?: return
         val isGroupThread = thread.isGroupRecipient
@@ -256,6 +274,38 @@ class VisibleMessageView : LinearLayout {
         }
         else {
             binding.emojiReactionsView.root.isVisible = false
+        }
+
+        // Make the icon for the file appear as sending if attachment download is not yet complete
+        // TODO: This seems to have a race-condition where other, previously downloaded attachments
+        // TODO: get the spinner icon (but do not spin) during download of the message we're
+        // TODO: actually downloading. Ask Harris what he thinks...
+        if (message.isMediaPending) { // && !message.isRead && !message.isDelivered) {
+            Log.d("[ACL]", "[VisibleMessageView] Message media is pending so applying spinner animation!")
+
+            // Create the animation
+            rotateAnimation = RotateAnimation(0f, 360f, Animation.RELATIVE_TO_SELF, 0.5f, Animation.RELATIVE_TO_SELF, 0.5f).also {
+                it.interpolator = LinearInterpolator()
+                it.repeatCount = 999999 // Animation.INFINITE - Note: If we set the repeat count to INFINITE then the `onAnimationEnd` callback is never called so we'll use a big number for repeats instead!
+                it.duration = 1000 // Duration is in milliseconds, so 1000ms is 1 second
+            }
+
+            // Set a custom animation listener on our rotate animation so when it stops (which
+            // occurs when the attachment download has completed) we can change the icon back to the
+            // file icon.
+            // TODO" This animation listener never triggers! Awesome! Thanks!
+            rotationAnimationListener = DocumentView.RotationAnimationListener(
+                binding.messageContentView.documentView.documentViewIconImageView,
+                binding.messageContentView.documentView.documentViewIconImageView.drawable
+            ).also { rotateAnimation?.setAnimationListener(it) }
+
+
+            // Set the icon image and start the rotation to act like a spinner
+            // Note: SOMETHING triggers a refresh when the file attachment download completes. It's
+            // not our listener (above, now commented) because even if we try to use it we never hit
+            // the `onAnimationEnd` callback! GRRR!!!
+            binding.messageContentView.documentView.documentViewIconImageView.setImageResource(R.drawable.ic_message_details__refresh)
+            binding.messageContentView.documentView.documentViewIconImageView.startAnimation(rotateAnimation)
         }
 
         // Populate content view

--- a/app/src/main/res/layout/view_document.xml
+++ b/app/src/main/res/layout/view_document.xml
@@ -10,10 +10,17 @@
     android:gravity="center"
     android:contentDescription="@string/AccessibilityId_document">
 
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/documentViewProgress"
+        style="@style/Widget.Material3.CircularProgressIndicator.Small"
+        android:indeterminate="true"
+        android:layout_width="36dp"
+        android:layout_height="36dp"/>
+
     <ImageView
         android:id="@+id/documentViewIconImageView"
-        android:layout_width="24dp"
-        android:layout_height="24dp"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
         android:src="@drawable/ic_document_large_light"
         app:tint="?android:textColorPrimary" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -470,6 +470,7 @@
     <string name="conversation_activity__quick_attachment_drawer_record_and_send_audio_description">Record and send audio attachment</string>
     <string name="conversation_activity__quick_attachment_drawer_lock_record_description">Lock recording of audio attachment</string>
     <string name="conversation_activity__enable_signal_for_sms">Enable Session for SMS</string>
+    <string name="conversation_activity__wait_until_attachment_has_finished_downloading">Please wait until attachment has finished downloading</string>
     <!-- conversation_input_panel -->
     <string name="conversation_input_panel__slide_to_cancel">Slide to cancel</string>
     <string name="conversation_input_panel__cancel">Cancel</string>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have tested my contribution on these devices:
 * Device A, Samsung S9+ on Android 9 / API 28
 * Virtual device W, Pixel 3a on Android 14 / API 34
 * Virtual device W, Android Y.Y.Z
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Attempting to download an attachment before the attachment has finished transferring from the network resulted in a toast with an error message being displayed ("Error while saving attachment to storage"). To fix this issue a check is performed about whether an attachment is still downloading or not, and if so and the user attempts to download the file before it's finished a toast says "Please wait until attachment has finished downloading". 

Further, a spinner has been added to the message `VisibleMessageContentView` which replaces the generic file icon and animates a spinner during download, then when the attachment download has completed the generic 'file' icon replaces the spinner.

All commits in this PR relate to fixing the same issue.

<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->