### PR TITLE
SES-697 - Add loading state when exporting logs

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -478,9 +478,8 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
                     Log.d("Loki-Avatar", "Uploading Avatar Finished");
                     return Unit.INSTANCE;
                 });
-            } catch (Exception exception) {
-                // Do nothing
-                Log.e("Loki-Avatar", "Uploading avatar failed", exception);
+            } catch (Exception e) {
+                Log.e("Loki-Avatar", "Uploading avatar failed.");
             }
         });
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/HelpSettingsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/HelpSettingsActivity.kt
@@ -5,9 +5,13 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.view.View.VISIBLE
+import android.widget.ProgressBar
+import android.widget.TextView
 import android.widget.Toast
 import androidx.preference.Preference
 import network.loki.messenger.R
+import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.PassphraseRequiredActionBarActivity
 import org.thoughtcrime.securesms.permissions.Permissions
 

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/HelpSettingsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/HelpSettingsActivity.kt
@@ -5,13 +5,10 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.view.View.VISIBLE
-import android.widget.ProgressBar
-import android.widget.TextView
 import android.widget.Toast
 import androidx.preference.Preference
+
 import network.loki.messenger.R
-import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.PassphraseRequiredActionBarActivity
 import org.thoughtcrime.securesms.permissions.Permissions
 

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/HelpSettingsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/HelpSettingsActivity.kt
@@ -5,10 +5,14 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.widget.ProgressBar
+import android.widget.TextView
 import android.widget.Toast
+import androidx.core.view.isInvisible
 import androidx.preference.Preference
 
 import network.loki.messenger.R
+import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.PassphraseRequiredActionBarActivity
 import org.thoughtcrime.securesms.permissions.Permissions
 
@@ -68,6 +72,19 @@ class HelpSettingsFragment: CorrectedPreferenceFragment() {
         }
     }
 
+    private fun updateExportButtonAndProgressBarUI(exportJobRunning: Boolean) {
+        this.activity?.runOnUiThread(Runnable {
+            // Change export logs button text
+            val exportLogsButton = this.activity?.findViewById(R.id.export_logs_button) as TextView?
+            if (exportLogsButton == null) { Log.w("Loki", "Could not find export logs button view.") }
+            exportLogsButton?.text = if (exportJobRunning) getString(R.string.cancel) else getString(R.string.activity_help_settings__export_logs)
+
+            // Show progress bar
+            val exportProgressBar = this.activity?.findViewById(R.id.export_progress_bar) as ProgressBar?
+            exportProgressBar?.isInvisible = !exportJobRunning
+        })
+    }
+
     private fun shareLogs() {
         Permissions.with(this)
             .request(Manifest.permission.WRITE_EXTERNAL_STORAGE)
@@ -77,7 +94,7 @@ class HelpSettingsFragment: CorrectedPreferenceFragment() {
                 Toast.makeText(requireActivity(), R.string.MediaPreviewActivity_unable_to_write_to_external_storage_without_permission, Toast.LENGTH_LONG).show()
             }
             .onAllGranted {
-                ShareLogsDialog().show(parentFragmentManager,"Share Logs Dialog")
+                ShareLogsDialog(::updateExportButtonAndProgressBarUI).show(parentFragmentManager,"Share Logs Dialog")
             }
             .execute()
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/ShareLogsDialog.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/ShareLogsDialog.kt
@@ -143,9 +143,6 @@ class ShareLogsDialog : DialogFragment() {
             }
         }.also { shareJob ->
             shareJob.invokeOnCompletion { handler ->
-                // Regardless of the job's success it has now completed so update the UI
-                //updateExportButtonAndProgressBarUI(false)
-
                 // Note: Don't show Toasts here directly - use `withContext(Main)` or such if req'd
                 handler?.message.let { msg ->
                     if (shareJob.isCancelled) {
@@ -164,7 +161,9 @@ class ShareLogsDialog : DialogFragment() {
                     }
                 }
 
+                // Regardless of the job's success it has now completed so update the UI
                 updateExportButtonAndProgressBarUI(false)
+                
                 dismiss()
             }
         }

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/ShareLogsDialog.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/ShareLogsDialog.kt
@@ -64,13 +64,12 @@ class ShareLogsDialog : DialogFragment() {
             // Change export logs button text
             val exportLogsButton = this.activity?.findViewById(R.id.export_logs_button) as TextView?
             if (exportLogsButton == null) { Log.w("Loki", "Could not find export logs button view.") }
-            // TODO: Pick "Cancel" from R.string.
-            exportLogsButton?.text = if (exportJobRunning) "Cancel" else "Export Logs"
+            exportLogsButton?.text = if (exportJobRunning) getString(R.string.cancel) else getString(R.string.activity_help_settings__export_logs)
 
             // Show progress bar
             val exportProgressBar = this.activity?.findViewById(R.id.export_progress_bar) as ProgressBar?
-            // Note: Not using `isVisible` because options are VISIBLE or GONE and I want to
-            // keep taking the space as INVISIBLE to avoid layout change.
+            // Note: I'm not using `isVisible` because those options are VISIBLE or GONE and I want
+            // to keep taking the space as INVISIBLE to avoid any layout change on show/hide.
             exportProgressBar?.visibility = if (exportJobRunning ) VISIBLE else INVISIBLE
         })
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/ShareLogsDialog.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/ShareLogsDialog.kt
@@ -10,23 +10,31 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Environment
 import android.provider.MediaStore
+import android.view.View.INVISIBLE
+import android.view.View.VISIBLE
 import android.webkit.MimeTypeMap
+import android.widget.ProgressBar
+import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.lifecycleScope
+
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+
 import network.loki.messenger.BuildConfig
 import network.loki.messenger.R
+
 import org.session.libsignal.utilities.ExternalStorageUtil
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.ApplicationContext
 import org.thoughtcrime.securesms.createSessionDialog
 import org.thoughtcrime.securesms.util.FileProviderUtil
 import org.thoughtcrime.securesms.util.StreamUtil
+
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -35,20 +43,49 @@ import java.util.concurrent.TimeUnit
 
 class ShareLogsDialog : DialogFragment() {
 
+    private val TAG = "ShareLogsDialog"
     private var shareJob: Job? = null
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog = createSessionDialog {
         title(R.string.dialog_share_logs_title)
         text(R.string.dialog_share_logs_explanation)
-        button(R.string.share, dismiss = false) { shareLogs() }
-        cancelButton { dismiss() }
+        button(R.string.share, dismiss = false) { runShareLogsJob() }
+        cancelButton { updateExportButtonAndProgressBarUI(false); dismiss() }
     }
 
-    private fun shareLogs() {
+    // If the share logs dialog loses focus the job gets cancelled so we'll update the UI state
+    override fun onPause() {
+        super.onPause()
+        updateExportButtonAndProgressBarUI(false)
+    }
+
+    private fun updateExportButtonAndProgressBarUI(exportJobRunning: Boolean) {
+        this.activity?.runOnUiThread(Runnable {
+            // Change export logs button text
+            val exportLogsButton = this.activity?.findViewById(R.id.export_logs_button) as TextView?
+            if (exportLogsButton == null) { Log.w("Loki", "Could not find export logs button view.") }
+            // TODO: Pick "Cancel" from R.string.
+            exportLogsButton?.text = if (exportJobRunning) "Cancel" else "Export Logs"
+
+            // Show progress bar
+            val exportProgressBar = this.activity?.findViewById(R.id.export_progress_bar) as ProgressBar?
+            // Note: Not using `isVisible` because options are VISIBLE or GONE and I want to
+            // keep taking the space as INVISIBLE to avoid layout change.
+            exportProgressBar?.visibility = if (exportJobRunning ) VISIBLE else INVISIBLE
+        })
+    }
+
+    private fun runShareLogsJob() {
+        // Cancel any existing share job that might already be running to start anew
         shareJob?.cancel()
+
+        updateExportButtonAndProgressBarUI(true)
+
         shareJob = lifecycleScope.launch(Dispatchers.IO) {
             val persistentLogger = ApplicationContext.getInstance(context).persistentLogger
             try {
+                Log.d(TAG, "Starting share logs job...")
+
                 val context = requireContext()
                 val outputUri: Uri = ExternalStorageUtil.getDownloadUri()
                 val mediaUri = getExternalFile()
@@ -60,6 +97,8 @@ class ShareLogsDialog : DialogFragment() {
 
                 val inputStream = persistentLogger.logs.get().byteInputStream()
                 val updateValues = ContentValues()
+
+                // Add details into the output or media files as appropriate
                 if (outputUri.scheme == ContentResolver.SCHEME_FILE) {
                     FileOutputStream(mediaUri.path).use { outputStream ->
                         StreamUtil.copy(inputStream, outputStream)
@@ -73,6 +112,7 @@ class ShareLogsDialog : DialogFragment() {
                         }
                     }
                 }
+
                 if (Build.VERSION.SDK_INT > 28) {
                     updateValues.put(MediaStore.MediaColumns.IS_PENDING, 0)
                 }
@@ -95,13 +135,37 @@ class ShareLogsDialog : DialogFragment() {
                     }
                     startActivity(Intent.createChooser(shareIntent, getString(R.string.share)))
                 }
-
-                dismiss()
             } catch (e: Exception) {
                 withContext(Main) {
                     Log.e("Loki", "Error saving logs", e)
                     Toast.makeText(context,"Error saving logs", Toast.LENGTH_LONG).show()
                 }
+                dismiss()
+            }
+        }.also { shareJob ->
+            shareJob.invokeOnCompletion { handler ->
+                // Regardless of the job's success it has now completed so update the UI
+                //updateExportButtonAndProgressBarUI(false)
+
+                // Note: Don't show Toasts here directly - use `withContext(Main)` or such if req'd
+                handler?.message.let { msg ->
+                    if (shareJob.isCancelled) {
+                        if (msg.isNullOrBlank()) {
+                            Log.w(TAG, "Share logs job was cancelled.")
+                        } else {
+                            Log.d(TAG, "Share logs job was cancelled. Reason: $msg")
+                        }
+
+                    }
+                    else if (shareJob.isCompleted) {
+                        Log.d(TAG, "Share logs job completed. Msg: $msg")
+                    }
+                    else {
+                        Log.w(TAG, "Share logs job finished while still Active. Msg: $msg")
+                    }
+                }
+
+                updateExportButtonAndProgressBarUI(false)
                 dismiss()
             }
         }
@@ -157,6 +221,5 @@ class ShareLogsDialog : DialogFragment() {
         }
         return context.contentResolver.insert(outputUri, contentValues)
     }
-
 
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/util/StreamUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/StreamUtil.java
@@ -10,6 +10,8 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.time.Instant;
+import java.time.LocalDateTime;
 
 /**
  * Utility methods for input and output streams.
@@ -85,6 +87,43 @@ public final class StreamUtil {
         while ((read = in.read(buffer)) != -1) {
             out.write(buffer, 0, read);
             total += read;
+        }
+
+        in.close();
+        out.close();
+
+        return total;
+    }
+
+    private static long getCurrentTimestampSeconds() { return System.currentTimeMillis() / 1000; }
+
+    public static long copyWithProgressUpdates(InputStream in, OutputStream out, long secondsBetweenUpdates) throws IOException {
+        byte[] buffer = new byte[64 * 1024];
+        int read;
+        long total = 0;
+
+        float totalInMB;
+        float copyDurationSecs = 0f;
+        long lastReportTimestampSeconds = getCurrentTimestampSeconds();
+
+
+        while ((read = in.read(buffer)) != -1) {
+            out.write(buffer, 0, read);
+            total += read;
+
+
+
+            if (getCurrentTimestampSeconds() - lastReportTimestampSeconds > secondsBetweenUpdates) {
+
+                totalInMB = (float)total / 1024f;
+
+                // Invoke event here and send totalInMB if we wanna
+                Log.d("[ACL]", "Total copied: " +  String.format("%.2f", totalInMB));
+
+                lastReportTimestampSeconds = getCurrentTimestampSeconds();
+            }
+
+
         }
 
         in.close();

--- a/app/src/main/java/org/thoughtcrime/securesms/util/StreamUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/StreamUtil.java
@@ -10,8 +10,6 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.time.Instant;
-import java.time.LocalDateTime;
 
 /**
  * Utility methods for input and output streams.

--- a/app/src/main/java/org/thoughtcrime/securesms/util/StreamUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/StreamUtil.java
@@ -94,41 +94,4 @@ public final class StreamUtil {
 
         return total;
     }
-
-    private static long getCurrentTimestampSeconds() { return System.currentTimeMillis() / 1000; }
-
-    public static long copyWithProgressUpdates(InputStream in, OutputStream out, long secondsBetweenUpdates) throws IOException {
-        byte[] buffer = new byte[64 * 1024];
-        int read;
-        long total = 0;
-
-        float totalInMB;
-        float copyDurationSecs = 0f;
-        long lastReportTimestampSeconds = getCurrentTimestampSeconds();
-
-
-        while ((read = in.read(buffer)) != -1) {
-            out.write(buffer, 0, read);
-            total += read;
-
-
-
-            if (getCurrentTimestampSeconds() - lastReportTimestampSeconds > secondsBetweenUpdates) {
-
-                totalInMB = (float)total / 1024f;
-
-                // Invoke event here and send totalInMB if we wanna
-                Log.d("[ACL]", "Total copied: " +  String.format("%.2f", totalInMB));
-
-                lastReportTimestampSeconds = getCurrentTimestampSeconds();
-            }
-
-
-        }
-
-        in.close();
-        out.close();
-
-        return total;
-    }
 }

--- a/app/src/main/res/layout/export_logs_widget.xml
+++ b/app/src/main/res/layout/export_logs_widget.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
     <TextView
         android:layout_gravity="center"
         style="@style/Widget.Session.Button.Common.Filled"
@@ -11,5 +11,6 @@
         android:paddingHorizontal="@dimen/medium_spacing"
         android:paddingVertical="12dp"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
+        android:layout_height="wrap_content" />
+
 </FrameLayout>

--- a/app/src/main/res/layout/export_logs_widget.xml
+++ b/app/src/main/res/layout/export_logs_widget.xml
@@ -4,6 +4,7 @@
     android:layout_height="match_parent">
 
     <TextView
+        android:id="@+id/export_logs_button"
         android:layout_gravity="center"
         style="@style/Widget.Session.Button.Common.Filled"
         android:textStyle="bold"

--- a/app/src/main/res/layout/preference_widget_progress.xml
+++ b/app/src/main/res/layout/preference_widget_progress.xml
@@ -13,14 +13,18 @@
         style="?android:attr/progressBarStyleHorizontal"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:indeterminate="true" />
+        android:indeterminate="true"
+        android:visibility="invisible" />
 
+    <!--
     <TextView
         android:id="@+id/export_progress_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"
         android:textSize="15dp"
-        tools:text="123 messages so far" />
+        android:paddingBottom="10dp"
+        android:text="456 messages so far" />
+    -->
 
 </LinearLayout>

--- a/app/src/main/res/layout/preference_widget_progress.xml
+++ b/app/src/main/res/layout/preference_widget_progress.xml
@@ -1,23 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:id="@+id/container"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:paddingBottom="16dp"
-              android:gravity="bottom">
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/export_progress_container"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom" >
 
-    <ProgressBar android:id="@+id/progress_bar"
-                 style="?android:attr/progressBarStyleHorizontal"
-                 android:layout_width="match_parent"
-                 android:layout_height="wrap_content"
-                 android:indeterminate="true"/>
+    <ProgressBar
+        android:id="@+id/export_progress_bar"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true" />
 
-    <TextView android:id="@+id/progress_text"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:gravity="center"
-              tools:text="1345 messages so far"/>
+    <TextView
+        android:id="@+id/export_progress_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:textSize="15dp"
+        tools:text="123 messages so far" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/preference_widget_progress.xml
+++ b/app/src/main/res/layout/preference_widget_progress.xml
@@ -16,15 +16,4 @@
         android:indeterminate="true"
         android:visibility="invisible" />
 
-    <!--
-    <TextView
-        android:id="@+id/export_progress_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:textSize="15dp"
-        android:paddingBottom="10dp"
-        android:text="456 messages so far" />
-    -->
-
 </LinearLayout>

--- a/app/src/main/res/xml/preferences_help.xml
+++ b/app/src/main/res/xml/preferences_help.xml
@@ -8,7 +8,7 @@
             android:summary="@string/activity_help_settings__report_bug_summary"
             android:widgetLayout="@layout/export_logs_widget" />
 
-        <!-- Note: Having this as `android:layout` rather than `android:layoutWidget` allows it to fit the screen -->
+        <!-- Note: Having this as `android:layout` rather than `android:layoutWidget` allows it to fit the screen width -->
         <Preference android:layout="@layout/preference_widget_progress" />
     </PreferenceCategory>
 

--- a/app/src/main/res/xml/preferences_help.xml
+++ b/app/src/main/res/xml/preferences_help.xml
@@ -6,39 +6,38 @@
             android:key="export_logs"
             android:title="@string/activity_help_settings__report_bug_title"
             android:summary="@string/activity_help_settings__report_bug_summary"
-            android:widgetLayout="@layout/export_logs_widget"/>
+            android:widgetLayout="@layout/export_logs_widget" />
+
+        <!-- Note: Having this as `android:layout` rather than `android:layoutWidget` allows it to fit the screen -->
+        <Preference android:layout="@layout/preference_widget_progress" />
     </PreferenceCategory>
 
     <PreferenceCategory>
         <Preference
             android:key="translate_session"
             android:title="@string/activity_help_settings__translate_session"
-            android:widgetLayout="@layout/preference_external_link"
-            />
+            android:widgetLayout="@layout/preference_external_link" />
     </PreferenceCategory>
 
     <PreferenceCategory>
         <Preference
             android:key="feedback"
             android:title="@string/activity_help_settings__feedback"
-            android:widgetLayout="@layout/preference_external_link"
-            />
+            android:widgetLayout="@layout/preference_external_link" />
     </PreferenceCategory>
 
     <PreferenceCategory>
         <Preference
             android:key="faq"
             android:title="@string/activity_help_settings__faq"
-            android:widgetLayout="@layout/preference_external_link"
-            />
+            android:widgetLayout="@layout/preference_external_link" />
     </PreferenceCategory>
 
     <PreferenceCategory>
         <Preference
             android:key="support"
             android:title="@string/activity_help_settings__support"
-            android:widgetLayout="@layout/preference_external_link"
-            />
+            android:widgetLayout="@layout/preference_external_link" />
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/libsession/src/main/java/org/session/libsession/avatars/AvatarHelper.java
+++ b/libsession/src/main/java/org/session/libsession/avatars/AvatarHelper.java
@@ -24,15 +24,9 @@ public class AvatarHelper {
   private static final String AVATAR_DIRECTORY = "avatars";
 
   public static InputStream getInputStreamFor(@NonNull Context context, @NonNull Address address)
+          throws FileNotFoundException
   {
-    try {
       return new FileInputStream(getAvatarFile(context, address));
-    }
-    catch (FileNotFoundException fnfe) {
-      // Catching this to prevent excessively verbose error output in LogCat
-      Log.e("Loki-Avatar", "Avatar upload failed - file not found.");
-    }
-    return null;
   }
 
   public static List<File> getAvatarFiles(@NonNull Context context) {

--- a/libsession/src/main/java/org/session/libsession/avatars/AvatarHelper.java
+++ b/libsession/src/main/java/org/session/libsession/avatars/AvatarHelper.java
@@ -8,9 +8,11 @@ import androidx.annotation.Nullable;
 import com.annimon.stream.Stream;
 
 import org.session.libsession.utilities.Address;
+import org.session.libsignal.utilities.Log;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,9 +24,14 @@ public class AvatarHelper {
   private static final String AVATAR_DIRECTORY = "avatars";
 
   public static InputStream getInputStreamFor(@NonNull Context context, @NonNull Address address)
-      throws IOException
   {
-    return new FileInputStream(getAvatarFile(context, address));
+    try {
+      return new FileInputStream(getAvatarFile(context, address));
+    }
+    catch (FileNotFoundException fnfe) {
+      Log.e("Loki-Avatar", "Uploading avatar failed - file not found for: " + address);
+    }
+    return null;
   }
 
   public static List<File> getAvatarFiles(@NonNull Context context) {

--- a/libsession/src/main/java/org/session/libsession/avatars/AvatarHelper.java
+++ b/libsession/src/main/java/org/session/libsession/avatars/AvatarHelper.java
@@ -29,7 +29,8 @@ public class AvatarHelper {
       return new FileInputStream(getAvatarFile(context, address));
     }
     catch (FileNotFoundException fnfe) {
-      Log.e("Loki-Avatar", "Uploading avatar failed - file not found for: " + address);
+      // Catching this to prevent excessively verbose error output in LogCat
+      Log.e("Loki-Avatar", "Uploading avatar failed for ID (print this stack trace for the gory details): " + address);
     }
     return null;
   }

--- a/libsession/src/main/java/org/session/libsession/avatars/AvatarHelper.java
+++ b/libsession/src/main/java/org/session/libsession/avatars/AvatarHelper.java
@@ -30,7 +30,7 @@ public class AvatarHelper {
     }
     catch (FileNotFoundException fnfe) {
       // Catching this to prevent excessively verbose error output in LogCat
-      Log.e("Loki-Avatar", "Uploading avatar failed for ID (print this stack trace for the gory details): " + address);
+      Log.e("Loki-Avatar", "Avatar upload failed - file not found.");
     }
     return null;
   }

--- a/libsession/src/main/java/org/session/libsession/avatars/ProfileContactPhoto.java
+++ b/libsession/src/main/java/org/session/libsession/avatars/ProfileContactPhoto.java
@@ -8,6 +8,7 @@ import androidx.annotation.Nullable;
 
 import org.session.libsession.utilities.Address;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.MessageDigest;
@@ -24,7 +25,7 @@ public class ProfileContactPhoto implements ContactPhoto {
   }
 
   @Override
-  public InputStream openInputStream(Context context) throws IOException {
+  public InputStream openInputStream(Context context) throws FileNotFoundException {
     return AvatarHelper.getInputStreamFor(context, address);
   }
 


### PR DESCRIPTION
### Contributor checklist
- [X] I have tested my contribution on these devices:
 * Virtual device Pixel 3a, Android 9 / API 28
 * Virtual device Pixel 3a, Android 14 / API 34
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Adds a progress bar to the Help | Report a Bug | [Share Logs] facility. Changed the [Export Logs] button text to [Cancel] while in progress. Losing focus on the job fragment removes the progress bar & puts the "Export Logs" text back, as does the job being cancelled or the job completing.

Also caught an AvatarHelper exception and printed less verbose msgs as it hits and prints a full stack trace all the time!
