### PR TITLE
SA1316 New messages are hidden under keyboard REDO

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -227,11 +227,13 @@
             android:name="org.thoughtcrime.securesms.conversation.v2.ConversationActivityV2"
             android:screenOrientation="portrait"
             android:parentActivityName="org.thoughtcrime.securesms.home.HomeActivity"
-            android:theme="@style/Theme.Session.DayNight.NoActionBar">
+            android:theme="@style/Theme.Session.DayNight.NoActionBar"
+            android:windowSoftInputMode="adjustResize" >
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="org.thoughtcrime.securesms.home.HomeActivity" />
         </activity>
+
         <activity
             android:name="org.thoughtcrime.securesms.conversation.v2.MessageDetailActivity"
             android:screenOrientation="portrait"

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -39,7 +39,6 @@ import androidx.activity.viewModels
 import androidx.annotation.DimenRes
 import androidx.core.text.set
 import androidx.core.text.toSpannable
-import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.drawToBitmap
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
@@ -351,7 +350,10 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
     private lateinit var reactionDelegate: ConversationReactionDelegate
     private val reactWithAnyEmojiStartPage = -1
 
-    private var currentWindowInsets: WindowInsetsCompat = WindowInsetsCompat.Builder().build()
+    // Properties for what message indices are visible previously & now, as well as the scroll state
+    private var previousLastVisibleRecyclerViewIndex: Int = -1
+    private var currentLastVisibleRecyclerViewIndex: Int = -1
+    private var recyclerScrollState: Int = RecyclerView.SCROLL_STATE_IDLE
 
     // region Settings
     companion object {
@@ -423,8 +425,10 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
         setUpBlockedBanner()
         binding!!.searchBottomBar.setEventListener(this)
         updateSendAfterApprovalText()
-        //showOrHideInputIfNeeded() Not required in onCreate we'll never hit this w/ the keyboard visible and never need to immediately display it
         setUpMessageRequestsBar()
+
+        // Note: Do not `showOrHideInputIfNeeded` here - we'll never start this activity w/ the
+        // keyboard visible and have no need to immediately display it.
 
         val weakActivity = WeakReference(this)
 
@@ -549,11 +553,6 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
     override fun onLoaderReset(cursor: Loader<Cursor>) {
         adapter.changeCursor(null)
     }
-
-    // Properties for what message indices are visible previously & now, as well as the scroll state
-    private var previousLastVisibleRecyclerViewIndex: Int = -1
-    private var currentLastVisibleRecyclerViewIndex: Int = -1
-    private var recyclerScrollState: Int = RecyclerView.SCROLL_STATE_IDLE
 
     // called from onCreate
     private fun setUpRecyclerView() {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -351,8 +351,8 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
     private val reactWithAnyEmojiStartPage = -1
 
     // Properties for what message indices are visible previously & now, as well as the scroll state
-    private var previousLastVisibleRecyclerViewIndex: Int = -1
-    private var currentLastVisibleRecyclerViewIndex: Int = -1
+    private var previousLastVisibleRecyclerViewIndex: Int = RecyclerView.NO_POSITION
+    private var currentLastVisibleRecyclerViewIndex:  Int = RecyclerView.NO_POSITION
     private var recyclerScrollState: Int = RecyclerView.SCROLL_STATE_IDLE
 
     // region Settings
@@ -578,7 +578,7 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
 
     private fun scrollToMostRecentMessageIfWeShould() {
         // Grab an initial 'previous' last visible message..
-        if (previousLastVisibleRecyclerViewIndex == -1) {
+        if (previousLastVisibleRecyclerViewIndex == RecyclerView.NO_POSITION) {
             previousLastVisibleRecyclerViewIndex = layoutManager?.findLastVisibleItemPosition()!!
         }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationAdapter.kt
@@ -101,16 +101,13 @@ class ConversationAdapter(
         @Suppress("NAME_SHADOWING")
         val viewType = ViewType.allValues[viewType]
         return when (viewType) {
-            ViewType.Visible -> VisibleMessageViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.view_visible_message, parent, false)) // ACL This is where new messages you send get inflated
+            ViewType.Visible -> VisibleMessageViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.view_visible_message, parent, false))
             ViewType.Control -> ControlMessageViewHolder(ControlMessageView(context))
             else -> throw IllegalStateException("Unexpected view type: $viewType.")
         }
     }
 
     override fun onBindItemViewHolder(viewHolder: ViewHolder, cursor: Cursor) {
-
-        Log.d("[ACL]", "Hit onBindItemViewHolder!")
-
         val message = getMessage(cursor)!!
         val position = viewHolder.adapterPosition
         val messageBefore = getMessageBefore(position, cursor)
@@ -211,9 +208,6 @@ class ConversationAdapter(
 
     override fun changeCursor(cursor: Cursor?) {
         super.changeCursor(cursor)
-
-        Log.d("[ACL]", "Hit change cursor - new cursor position: ${cursor?.position}")
-
         val toRemove = mutableSetOf<MessageRecord>()
         val toDeselect = mutableSetOf<Pair<Int, MessageRecord>>()
         for (selected in selectedItems) {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationAdapter.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.launch
 import network.loki.messenger.R
 import network.loki.messenger.databinding.ViewVisibleMessageBinding
 import org.session.libsession.messaging.contacts.Contact
+import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.conversation.v2.messages.ControlMessageView
 import org.thoughtcrime.securesms.conversation.v2.messages.VisibleMessageView
 import org.thoughtcrime.securesms.conversation.v2.messages.VisibleMessageViewDelegate
@@ -100,13 +101,16 @@ class ConversationAdapter(
         @Suppress("NAME_SHADOWING")
         val viewType = ViewType.allValues[viewType]
         return when (viewType) {
-            ViewType.Visible -> VisibleMessageViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.view_visible_message, parent, false))
+            ViewType.Visible -> VisibleMessageViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.view_visible_message, parent, false)) // ACL This is where new messages you send get inflated
             ViewType.Control -> ControlMessageViewHolder(ControlMessageView(context))
             else -> throw IllegalStateException("Unexpected view type: $viewType.")
         }
     }
 
     override fun onBindItemViewHolder(viewHolder: ViewHolder, cursor: Cursor) {
+
+        Log.d("[ACL]", "Hit onBindItemViewHolder!")
+
         val message = getMessage(cursor)!!
         val position = viewHolder.adapterPosition
         val messageBefore = getMessageBefore(position, cursor)
@@ -207,6 +211,9 @@ class ConversationAdapter(
 
     override fun changeCursor(cursor: Cursor?) {
         super.changeCursor(cursor)
+
+        Log.d("[ACL]", "Hit change cursor - new cursor position: ${cursor?.position}")
+
         val toRemove = mutableSetOf<MessageRecord>()
         val toDeselect = mutableSetOf<Pair<Int, MessageRecord>>()
         for (selected in selectedItems) {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationRecyclerView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationRecyclerView.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.VelocityTracker
+import android.view.View
 import androidx.recyclerview.widget.RecyclerView
+import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.util.disableClipping
 import org.thoughtcrime.securesms.util.toPx
 import kotlin.math.abs
@@ -18,9 +20,7 @@ class ConversationRecyclerView : RecyclerView {
     constructor(context: Context, attrs: AttributeSet) : super(context, attrs) { initialize() }
     constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(context, attrs, defStyleAttr) { initialize() }
 
-    private fun initialize() {
-        disableClipping()
-    }
+    private fun initialize() { disableClipping() }
 
     override fun onInterceptTouchEvent(e: MotionEvent): Boolean {
         val velocityTracker = velocityTracker ?: return super.onInterceptTouchEvent(e)

--- a/app/src/main/java/org/thoughtcrime/securesms/database/CursorRecyclerViewAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/CursorRecyclerViewAdapter.java
@@ -242,7 +242,7 @@ public abstract class CursorRecyclerViewAdapter<VH extends RecyclerView.ViewHold
     public void onChanged() {
       super.onChanged();
       valid = true;
-      notifyDataSetChanged(); // ACL try without this
+      //notifyDataSetChanged(); // ACL try without this
     }
 
     @Override

--- a/app/src/main/java/org/thoughtcrime/securesms/database/CursorRecyclerViewAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/CursorRecyclerViewAdapter.java
@@ -27,6 +27,8 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder;
 import android.view.View;
 import android.view.ViewGroup;
 
+import org.session.libsignal.utilities.Log;
+
 /**
  * RecyclerView.Adapter that manages a Cursor, comparable to the CursorAdapter usable in ListView/GridView.
  */
@@ -50,6 +52,7 @@ public abstract class CursorRecyclerViewAdapter<VH extends RecyclerView.ViewHold
     }
   }
 
+  // Constructor
   protected CursorRecyclerViewAdapter(Context context, Cursor cursor) {
     this.context = context;
     this.cursor = cursor;
@@ -143,7 +146,7 @@ public abstract class CursorRecyclerViewAdapter<VH extends RecyclerView.ViewHold
     switch (viewType) {
     case HEADER_TYPE: return new HeaderFooterViewHolder(header);
     case FOOTER_TYPE: return new HeaderFooterViewHolder(footer);
-    default:          return onCreateItemViewHolder(parent, viewType);
+    default:          return onCreateItemViewHolder(parent, viewType); // ACL This is passing back a ViewHolder!
     }
   }
 
@@ -160,9 +163,7 @@ public abstract class CursorRecyclerViewAdapter<VH extends RecyclerView.ViewHold
 
   public abstract void onBindItemViewHolder(VH viewHolder, @NonNull Cursor cursor);
 
-  protected void onBindFastAccessItemViewHolder(VH viewHolder, int position) {
-
-  }
+  protected void onBindFastAccessItemViewHolder(VH viewHolder, int position) { }
 
   @Override
   public final int getItemViewType(int position) {
@@ -241,6 +242,7 @@ public abstract class CursorRecyclerViewAdapter<VH extends RecyclerView.ViewHold
     public void onChanged() {
       super.onChanged();
       valid = true;
+      notifyDataSetChanged(); // ACL try without this
     }
 
     @Override

--- a/app/src/main/java/org/thoughtcrime/securesms/database/CursorRecyclerViewAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/CursorRecyclerViewAdapter.java
@@ -146,7 +146,7 @@ public abstract class CursorRecyclerViewAdapter<VH extends RecyclerView.ViewHold
     switch (viewType) {
     case HEADER_TYPE: return new HeaderFooterViewHolder(header);
     case FOOTER_TYPE: return new HeaderFooterViewHolder(footer);
-    default:          return onCreateItemViewHolder(parent, viewType); // ACL This is passing back a ViewHolder!
+    default:          return onCreateItemViewHolder(parent, viewType);
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/util/GeneralUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/GeneralUtilities.kt
@@ -37,3 +37,8 @@ val RecyclerView.isScrolledToBottom: Boolean
     get() = computeVerticalScrollOffset().coerceAtLeast(0) +
             computeVerticalScrollExtent() +
             toPx(50, resources) >= computeVerticalScrollRange()
+
+val RecyclerView.isScrolledToWithin30dpOfBottom: Boolean
+    get() = computeVerticalScrollOffset().coerceAtLeast(0) +
+            computeVerticalScrollExtent() +
+            toPx(30, resources) >= computeVerticalScrollRange()

--- a/app/src/main/java/org/thoughtcrime/securesms/util/GeneralUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/GeneralUtilities.kt
@@ -37,3 +37,11 @@ val RecyclerView.isScrolledToBottom: Boolean
     get() = computeVerticalScrollOffset().coerceAtLeast(0) +
             computeVerticalScrollExtent() +
             toPx(50, resources) >= computeVerticalScrollRange()
+
+// Extension property to determine if we should scroll down in the conversation view to show new
+// messages or not. Note: The 30dp value is taken from the JIRA issue at:
+// https://optf.atlassian.net/browse/SES-1145
+val RecyclerView.shouldScrollToShowNewMessages: Boolean
+    get() = computeVerticalScrollOffset().coerceAtLeast(0) +
+            computeVerticalScrollExtent() +
+            toPx(30, resources) >= computeVerticalScrollRange()

--- a/app/src/main/java/org/thoughtcrime/securesms/util/GeneralUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/GeneralUtilities.kt
@@ -41,7 +41,7 @@ val RecyclerView.isScrolledToBottom: Boolean
 // Extension property to determine if we should scroll down in the conversation view to show new
 // messages or not. Note: The 30dp value is taken from the JIRA issue at:
 // https://optf.atlassian.net/browse/SES-1145
-val RecyclerView.shouldScrollToShowNewMessages: Boolean
+val RecyclerView.shouldScrollToBottomMessages: Boolean
     get() = computeVerticalScrollOffset().coerceAtLeast(0) +
             computeVerticalScrollExtent() +
             toPx(30, resources) >= computeVerticalScrollRange()

--- a/app/src/main/java/org/thoughtcrime/securesms/util/GeneralUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/GeneralUtilities.kt
@@ -37,11 +37,3 @@ val RecyclerView.isScrolledToBottom: Boolean
     get() = computeVerticalScrollOffset().coerceAtLeast(0) +
             computeVerticalScrollExtent() +
             toPx(50, resources) >= computeVerticalScrollRange()
-
-// Extension property to determine if we should scroll down in the conversation view to show new
-// messages or not. Note: The 30dp value is taken from the JIRA issue at:
-// https://optf.atlassian.net/browse/SES-1145
-val RecyclerView.shouldScrollToBottomMessages: Boolean
-    get() = computeVerticalScrollOffset().coerceAtLeast(0) +
-            computeVerticalScrollExtent() +
-            toPx(30, resources) >= computeVerticalScrollRange()

--- a/app/src/main/res/drawable/cross.xml
+++ b/app/src/main/res/drawable/cross.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="100dp"
+    android:height="100dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+
+    <path
+        android:pathData="M0,0 L100,100 M0,100 L100,0"
+        android:strokeWidth="1"
+        android:strokeColor="@android:color/white" />
+</vector>

--- a/app/src/main/res/layout/activity_conversation_v2.xml
+++ b/app/src/main/res/layout/activity_conversation_v2.xml
@@ -22,7 +22,7 @@
     </androidx.appcompat.widget.Toolbar>
 
     <!--
-    Add this to the below recycler view if you need to debug adjustSize issues:
+    Add this to the below recycler view if you need to debug activity `adjustResize` issues:
     android:background="@drawable/cross"
     -->
     <org.thoughtcrime.securesms.conversation.v2.ConversationRecyclerView

--- a/app/src/main/res/layout/activity_conversation_v2.xml
+++ b/app/src/main/res/layout/activity_conversation_v2.xml
@@ -31,6 +31,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_above="@+id/typingIndicatorViewContainer"
+        android:background="@drawable/cross"
         android:layout_below="@id/toolbar" />
 
 

--- a/app/src/main/res/layout/activity_conversation_v2.xml
+++ b/app/src/main/res/layout/activity_conversation_v2.xml
@@ -27,7 +27,8 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_above="@+id/typingIndicatorViewContainer"
-        android:layout_below="@id/toolbar" />
+        android:layout_below="@id/toolbar"
+        android:background="@drawable/cross" />
 
     <org.thoughtcrime.securesms.conversation.v2.components.TypingIndicatorViewContainer
         android:focusable="false"

--- a/app/src/main/res/layout/activity_conversation_v2.xml
+++ b/app/src/main/res/layout/activity_conversation_v2.xml
@@ -21,14 +21,18 @@
 
     </androidx.appcompat.widget.Toolbar>
 
+    <!--
+    Add this to the below recycler view if you need to debug adjustSize issues:
+    android:background="@drawable/cross"
+    -->
     <org.thoughtcrime.securesms.conversation.v2.ConversationRecyclerView
         android:focusable="false"
         android:id="@+id/conversationRecyclerView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_above="@+id/typingIndicatorViewContainer"
-        android:layout_below="@id/toolbar"
-        android:background="@drawable/cross" />
+        android:layout_below="@id/toolbar" />
+
 
     <org.thoughtcrime.securesms.conversation.v2.components.TypingIndicatorViewContainer
         android:focusable="false"

--- a/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
+++ b/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
@@ -24,4 +24,17 @@ object ThreadUtils {
         executor.allowCoreThreadTimeOut(true)
         return executor
     }
+
+    // Helper method to just print the current stack trace so you can see where things are being
+    // called from without throwing then catching an exception and printing its details. For example
+    // if there are multiple ways to get to a given method and you don't know which code path was
+    // taken you can call `ThreadUtils.logCurrentThreadStackTrace` from inside the method being
+    // called to see how you got there.
+    @JvmStatic
+    fun logCurrentThreadStackTrace(tag: String = "ThreadUtils") {
+        val stackTrace = Thread.currentThread().stackTrace
+        for (element in stackTrace) {
+            Log.d(tag, element.className + "." + element.methodName + "(" + element.fileName + ":" + element.lineNumber + ")")
+        }
+    }
 }


### PR DESCRIPTION
### Contributor checklist
- [X] I have tested my contribution on these devices:
 * Samsung 9+ Android 9 / API 28
 * Virtual Pixel 3a Android 9 / API 28
 * Virtual Pixel 3a Android 14 / API 34
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
When the user is at the bottom of a conversation / group and they bring up the soft keyboard the conversation view is now resized and scrolled to the bottom (to maintain their position).

When the user is NOT at the bottom of a conversation / group then the above does not happen and the "scroll to bottom" button is visible (as usual).

When a user is at the bottom of a conversation and receives a message the conversation view is scrolled to display the new message even if the soft keyboard is visible (while as before, if they are NOT at the bottom of the conversation and have the keyboard up and receive a message the 'scroll to bottom' button is displayed).

Tested by sending multiple messages between accounts with & without the soft keyboard being displayed, and while being at various points in the conversation (in terms of scrolling). All seems to work as it should.