### PR TITLE
SA1039 - Push notifications for message requestes [REDONE]

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.java
@@ -424,7 +424,7 @@ public class DefaultMessageNotifier implements MessageNotifier {
     }
 
     Log.d("[ACL]", "Doing notification from ALPHA");
-    if (skipNotificationOfMsgRequest) {
+    if (!skipNotificationOfMsgRequest) {
       Notification notification = builder.build();
       NotificationManagerCompat.from(context).notify(notificationId, notification);
       Log.i(TAG, "Posted notification. " + notification.toString());
@@ -497,6 +497,9 @@ public class DefaultMessageNotifier implements MessageNotifier {
 
     int loopIndex = 0;
     while ((record = reader.getNext()) != null) {
+
+      Log.d("[ACL]", "Loop index is: " + loopIndex);
+
       long         id                    = record.getId();
       boolean      mms                   = record.isMms() || record.isMmsNotification();
       Recipient    recipient             = record.getIndividualRecipient();
@@ -517,7 +520,9 @@ public class DefaultMessageNotifier implements MessageNotifier {
 
         // If this is a message request AND (we've received more than a single message from this person OR we do NOT have hidden message requests) then skip without raising a message request notification
         if (lastMsgWasMessageRequest) {
-          Log.d("[ACL]", "Loop index is: " + loopIndex);
+          // Initially we'll assume that we do NOT want to skip notification of this message request
+          skipNotificationOfMsgRequest = false;
+
 
           if (threadDatabase.getMessageCount(threadId) >= 1) {
             Log.d("[ACL]", "Skipping message request notification because we already have 1 or more message requests from this unapproved contact.");

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/DefaultMessageNotifier.java
@@ -427,6 +427,9 @@ public class DefaultMessageNotifier implements MessageNotifier {
     if (!skipNotificationOfMsgRequest) {
       Notification notification = builder.build();
       NotificationManagerCompat.from(context).notify(notificationId, notification);
+
+      // UPDATE THE COUNTER ON THE HOME SCREEN HERE
+
       Log.i(TAG, "Posted notification. " + notification.toString());
     }
   }


### PR DESCRIPTION
# DRAFT 
- "[ACL]" debug tags will be removed when we're happy w/ it in general,
- Noticed a bug whereby the message requests count does not update when receiving a MR from a second source (but if you close and re-open the app it gets updated properly - not sure if I caused this or it's an existing bug).
- Noticed a bug whereby Virtual Android API 23 will not connect to loki network! I very much doubt I caused this one...

### Contributor checklist
- [X] I have tested my contribution on these devices:
* Samsung S9+ Android 9 / API 28
* Virtual Pixel 3a Android 9 / API 28
* Virtual Pixel 3a Android 14 / API 34
- [X] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Allows message requests to create notifications if notifications are allowed. Only one notification is shown per messaging user to avoid message request spam. 
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
