### PR TITLE
Fix NPE on null display name

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -182,7 +182,7 @@ open class Storage(
     }
 
     override fun getUserProfile(): Profile {
-        val displayName = TextSecurePreferences.getProfileName(context)!!
+        val displayName = TextSecurePreferences.getProfileName(context)
         val profileKey = ProfileKeyUtil.getProfileKey(context)
         val profilePictureUrl = TextSecurePreferences.getProfilePictureURL(context)
         return Profile(displayName, profileKey, profilePictureUrl)

--- a/libsession/src/main/java/org/session/libsession/messaging/messages/visible/Profile.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/messages/visible/Profile.kt
@@ -4,10 +4,11 @@ import com.google.protobuf.ByteString
 import org.session.libsignal.utilities.Log
 import org.session.libsignal.protos.SignalServiceProtos
 
-class Profile() {
-    var displayName: String? = null
-    var profileKey: ByteArray? = null
+class Profile(
+    var displayName: String? = null,
+    var profileKey: ByteArray? = null,
     var profilePictureURL: String? = null
+) {
 
     companion object {
         const val TAG = "Profile"
@@ -23,12 +24,6 @@ class Profile() {
                 return Profile(displayName)
             }
         }
-    }
-
-    constructor(displayName: String, profileKey: ByteArray? = null, profilePictureURL: String? = null) : this() {
-        this.displayName = displayName
-        this.profileKey = profileKey
-        this.profilePictureURL = profilePictureURL
     }
 
     fun toProto(): SignalServiceProtos.DataMessage? {


### PR DESCRIPTION
Small bug introduced in disappearing messages.

If your display name cannot be retrieved when you link a device then display name will be null, but we asserted it was non-null which is not necessary.