### PR TITLE
SES1688 - Deleting last message in conversation, group, or community leaves the RecyclerView in a broken state

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -1112,6 +1112,7 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
         val blindedRecipient = viewModel.blindedRecipient
         val binding = binding ?: return
         val openGroup = viewModel.openGroup
+
         val (textResource, insertParam) = when {
             recipient.isLocalNumber -> R.string.activity_conversation_empty_state_note_to_self to null
             openGroup != null && !openGroup.canWrite -> R.string.activity_conversation_empty_state_read_only to recipient.toShortString()
@@ -1883,11 +1884,13 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
             return
         }
 
+
+
         val allSentByCurrentUser = messages.all { it.isOutgoing }
         val allHasHash = messages.all { lokiMessageDb.getMessageServerHash(it.id, it.isMms) != null }
 
-        // If the recipient is a community then we delete the message for everyone
-        if (recipient.isCommunityRecipient) {
+        // If the recipient is a community OR a Note-to-Self then we delete the message for everyone
+        if (recipient.isCommunityRecipient || recipient.isLocalNumber) {
             val messageCount = 1 // Only used for plurals string
             showSessionDialog {
                 title(resources.getQuantityString(R.plurals.ConversationFragment_delete_selected_messages, messageCount, messageCount))
@@ -1917,8 +1920,7 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
             }
             bottomSheet.show(supportFragmentManager, bottomSheet.tag)
         }
-        else // Finally, if this is a closed group and you are deleting someone else's message(s)
-        // then we can only delete locally.
+        else // Finally, if this is a closed group and you are deleting someone else's message(s) then we can only delete locally.
         {
             val messageCount = 1
             showSessionDialog {
@@ -2027,7 +2029,6 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
         val message = messages.first() as MmsMessageRecord
 
         // Do not allow the user to download a file attachment before it has finished downloading
-        // TODO: Localise the msg in this toast!
         if (message.isMediaPending) {
             Toast.makeText(this, resources.getString(R.string.conversation_activity__wait_until_attachment_has_finished_downloading), Toast.LENGTH_LONG).show()
             return

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -1883,9 +1883,7 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
             Log.w("ConversationActivityV2", "Asked to delete messages but could not obtain viewModel recipient - aborting.")
             return
         }
-
-
-
+        
         val allSentByCurrentUser = messages.all { it.isOutgoing }
         val allHasHash = messages.all { lokiMessageDb.getMessageServerHash(it.id, it.isMms) != null }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/database/MmsDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MmsDatabase.kt
@@ -1095,8 +1095,7 @@ class MmsDatabase(context: Context, databaseHelper: SQLCipherOpenHelper) : Messa
         }
         val whereString = where.substring(0, where.length - 4)
         try {
-            cursor =
-                db!!.query(TABLE_NAME, arrayOf<String?>(ID), whereString, null, null, null, null)
+            cursor = db!!.query(TABLE_NAME, arrayOf<String?>(ID), whereString, null, null, null, null)
             val toDeleteStringMessageIds = mutableListOf<String>()
             while (cursor.moveToNext()) {
                 toDeleteStringMessageIds += cursor.getLong(0).toString()

--- a/app/src/main/java/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -633,6 +633,7 @@ public class SmsDatabase extends MessagingDatabase {
     SQLiteDatabase db = databaseHelper.getWritableDatabase();
     long threadId = getThreadIdForMessage(messageId);
     db.delete(TABLE_NAME, ID_WHERE, new String[] {messageId+""});
+    notifyConversationListeners(threadId);
     boolean threadDeleted = DatabaseComponent.get(context).threadDatabase().update(threadId, false, true);
     return threadDeleted;
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -515,14 +515,6 @@ public class ThreadDatabase extends Database {
     return getConversationList(where);
   }
 
-  /*
-  public Cursor getArchivedConversationList() {
-    String where  = "(" + MESSAGE_COUNT + " != 0 OR " + GroupDatabase.TABLE_NAME + "." + GROUP_ID + " LIKE '" + COMMUNITY_PREFIX + "%') " +
-            "AND " + ARCHIVED + " = 1 ";
-    return getConversationList(where);
-  }
-  */
-
   private Cursor getConversationList(String where) {
     SQLiteDatabase db     = databaseHelper.getReadableDatabase();
     String         query  = createQuery(where, 0);
@@ -752,10 +744,7 @@ public class ThreadDatabase extends Database {
       return true;
     }
 
-    MmsSmsDatabase.Reader reader = null;
-
-    try {
-      reader = mmsSmsDatabase.readerFor(mmsSmsDatabase.getConversationSnippet(threadId));
+    try (MmsSmsDatabase.Reader reader = mmsSmsDatabase.readerFor(mmsSmsDatabase.getConversationSnippet(threadId))) {
       MessageRecord record = null;
       if (reader != null) {
         record = reader.getNext();
@@ -777,7 +766,6 @@ public class ThreadDatabase extends Database {
         return false;
       }
     } finally {
-      if (reader != null) { reader.close(); }
       notifyConversationListListeners();
       notifyConversationListeners(threadId);
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -515,11 +515,13 @@ public class ThreadDatabase extends Database {
     return getConversationList(where);
   }
 
+  /*
   public Cursor getArchivedConversationList() {
     String where  = "(" + MESSAGE_COUNT + " != 0 OR " + GroupDatabase.TABLE_NAME + "." + GROUP_ID + " LIKE '" + COMMUNITY_PREFIX + "%') " +
             "AND " + ARCHIVED + " = 1 ";
     return getConversationList(where);
   }
+  */
 
   private Cursor getConversationList(String where) {
     SQLiteDatabase db     = databaseHelper.getReadableDatabase();
@@ -771,11 +773,11 @@ public class ThreadDatabase extends Database {
           deleteThread(threadId);
           return true;
         }
+        // todo: add empty snippet that clears existing data
         return false;
       }
     } finally {
-      if (reader != null)
-        reader.close();
+      if (reader != null) { reader.close(); }
       notifyConversationListListeners();
       notifyConversationListeners(threadId);
     }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have tested my contribution on these devices:
 * Virtual Android 9 API 28
 * Virtual Android 14 API 34
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Fixes the issue whereby on deletion of the final message in a conversation, group, or community the RecyclerView would get itself in a broken state on the device which performed the delete operation. In this state the view of the deleted message remained visible but was unusable, and the user needed to manually back out of the conversation/group/community to get things back to normal.
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
