### PR TITLE
[SES-1728] Fix spacing when title is absent

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/SessionDialogBuilder.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/SessionDialogBuilder.kt
@@ -7,7 +7,9 @@ import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.Button
 import android.widget.LinearLayout
+import android.widget.LinearLayout.LayoutParams
 import android.widget.LinearLayout.VERTICAL
+import android.widget.Space
 import android.widget.TextView
 import androidx.annotation.AttrRes
 import androidx.annotation.LayoutRes
@@ -15,12 +17,10 @@ import androidx.annotation.StringRes
 import androidx.annotation.StyleRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.setMargins
-import androidx.core.view.setPadding
 import androidx.core.view.updateMargins
 import androidx.fragment.app.Fragment
 import network.loki.messenger.R
 import org.thoughtcrime.securesms.util.toPx
-
 
 @DslMarker
 @Target(AnnotationTarget.CLASS, AnnotationTarget.TYPE)
@@ -37,7 +37,9 @@ class SessionDialogBuilder(val context: Context) {
     private var dialog: AlertDialog? = null
     private fun dismiss() = dialog?.dismiss()
 
-    private val topView = LinearLayout(context).apply { orientation = VERTICAL }
+    private val topView = LinearLayout(context)
+        .apply { setPadding(0, dp20, 0, 0) }
+        .apply { orientation = VERTICAL }
         .also(dialogBuilder::setCustomTitle)
     private val contentView = LinearLayout(context).apply { orientation = VERTICAL }
     private val buttonLayout = LinearLayout(context)
@@ -53,17 +55,16 @@ class SessionDialogBuilder(val context: Context) {
 
     fun title(text: CharSequence?) = title(text?.toString())
     fun title(text: String?) {
-        text(text, R.style.TextAppearance_AppCompat_Title) { setPadding(dp20) }
+        text(text, R.style.TextAppearance_AppCompat_Title) { setPadding(dp20, 0, dp20, 0) }
     }
 
     fun text(@StringRes id: Int, style: Int = 0) = text(context.getString(id), style)
     fun text(text: CharSequence?, @StyleRes style: Int = 0) {
         text(text, style) {
             layoutParams = LinearLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT)
-                .apply { updateMargins(dp40, 0, dp40, dp20) }
+                .apply { updateMargins(dp40, 0, dp40, 0) }
         }
     }
-
 
     private fun text(text: CharSequence?, @StyleRes style: Int, modify: TextView.() -> Unit) {
         text ?: return
@@ -73,6 +74,10 @@ class SessionDialogBuilder(val context: Context) {
                 textAlignment = View.TEXT_ALIGNMENT_CENTER
                 modify()
             }.let(topView::addView)
+
+        Space(context).apply {
+            layoutParams = LayoutParams(0, dp20)
+        }.let(topView::addView)
     }
 
     fun view(view: View) = contentView.addView(view)
@@ -126,7 +131,7 @@ class SessionDialogBuilder(val context: Context) {
             setText(text)
             contentDescription = resources.getString(contentDescriptionRes)
             layoutParams = LinearLayout.LayoutParams(WRAP_CONTENT, WRAP_CONTENT, 1f)
-                .apply { setMargins(toPx(20, resources)) }
+                .apply { setMargins(dp20) }
             setOnClickListener {
                 listener.invoke()
                 if (dismiss) dismiss()


### PR DESCRIPTION
This PR fixes an issue where dialogs with no title would have no space at the top of the dialog.

<img width="327" alt="Screen Shot 2024-04-12 at 11 34 20 am" src="https://github.com/oxen-io/session-android/assets/9282178/0e954e59-81f3-4058-a829-1c1de89e8a20">
<img width="334" alt="Screen Shot 2024-04-12 at 11 09 45 am" src="https://github.com/oxen-io/session-android/assets/9282178/a40225d1-1de3-4b39-a1d8-d6801c139db2">
