### PR TITLE
SES-1727 Mentions text is the wrong colour

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/BaseActionBarActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/BaseActionBarActivity.java
@@ -39,15 +39,20 @@ public abstract class BaseActionBarActivity extends AppCompatActivity {
   public int getDesiredTheme() {
     ThemeState themeState = ActivityUtilitiesKt.themeState(getPreferences());
     int userSelectedTheme = themeState.getTheme();
+
+    // If the user has configured Session to follow the system light/dark theme mode then do so..
     if (themeState.getFollowSystem()) {
-      // do light or dark based on the selected theme
+
+      // Use light or dark versions of the user's theme based on light-mode / dark-mode settings
       boolean isDayUi = UiModeUtilities.isDayUiMode(this);
       if (userSelectedTheme == R.style.Ocean_Dark || userSelectedTheme == R.style.Ocean_Light) {
         return isDayUi ? R.style.Ocean_Light : R.style.Ocean_Dark;
       } else {
         return isDayUi ? R.style.Classic_Light : R.style.Classic_Dark;
       }
-    } else {
+    }
+    else // ..otherwise just return their selected theme.
+    {
       return userSelectedTheme;
     }
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.conversation.v2.messages
 
 import android.content.Context
+import android.content.res.TypedArray
 import android.graphics.Color
 import android.graphics.Rect
 import android.text.Spannable
@@ -9,6 +10,7 @@ import android.text.style.ForegroundColorSpan
 import android.text.style.URLSpan
 import android.text.util.Linkify
 import android.util.AttributeSet
+import android.util.TypedValue
 import android.view.MotionEvent
 import android.view.View
 import androidx.annotation.ColorInt
@@ -44,6 +46,7 @@ import org.thoughtcrime.securesms.util.SearchUtil
 import org.thoughtcrime.securesms.util.getAccentColor
 import java.util.Locale
 import kotlin.math.roundToInt
+
 
 class VisibleMessageContentView : ConstraintLayout {
     private val binding: ViewVisibleMessageContentBinding by lazy { ViewVisibleMessageContentBinding.bind(this) }
@@ -310,6 +313,18 @@ class VisibleMessageContentView : ConstraintLayout {
         fun getTextColor(context: Context, message: MessageRecord): Int = context.getColorFromAttr(
             if (message.isOutgoing) R.attr.message_sent_text_color else R.attr.message_received_text_color
         )
+
+        // Method to grab the appropriate attribute for a message colour.
+        // Note: This is an attribute, NOT a resource Id - see `getColorResourceIdFromAttr` for that.
+        fun getMessageTextColourAttr(messageIsOutgoing: Boolean): Int =
+            if (messageIsOutgoing) R.attr.message_sent_text_color else R.attr.message_received_text_color
+
+        // Method to get an actual R.id.<SOME_COLOUR> resource Id from an attribute such as R.attr.message_sent_text_color etc.
+        fun getColorResourceIdFromAttr(context: Context, attr: Int): Int {
+            val typedValue = TypedValue()
+            context.theme.resolveAttribute(attr, typedValue, true)
+            return typedValue.resourceId
+        }
     }
     // endregion
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
@@ -1,7 +1,6 @@
 package org.thoughtcrime.securesms.conversation.v2.messages
 
 import android.content.Context
-import android.content.res.TypedArray
 import android.graphics.Color
 import android.graphics.Rect
 import android.text.Spannable
@@ -10,7 +9,6 @@ import android.text.style.ForegroundColorSpan
 import android.text.style.URLSpan
 import android.text.util.Linkify
 import android.util.AttributeSet
-import android.util.TypedValue
 import android.view.MotionEvent
 import android.view.View
 import androidx.annotation.ColorInt
@@ -46,7 +44,6 @@ import org.thoughtcrime.securesms.util.SearchUtil
 import org.thoughtcrime.securesms.util.getAccentColor
 import java.util.Locale
 import kotlin.math.roundToInt
-
 
 class VisibleMessageContentView : ConstraintLayout {
     private val binding: ViewVisibleMessageContentBinding by lazy { ViewVisibleMessageContentBinding.bind(this) }
@@ -313,18 +310,6 @@ class VisibleMessageContentView : ConstraintLayout {
         fun getTextColor(context: Context, message: MessageRecord): Int = context.getColorFromAttr(
             if (message.isOutgoing) R.attr.message_sent_text_color else R.attr.message_received_text_color
         )
-
-        // Method to grab the appropriate attribute for a message colour.
-        // Note: This is an attribute, NOT a resource Id - see `getColorResourceIdFromAttr` for that.
-        fun getMessageTextColourAttr(messageIsOutgoing: Boolean): Int =
-            if (messageIsOutgoing) R.attr.message_sent_text_color else R.attr.message_received_text_color
-
-        // Method to get an actual R.id.<SOME_COLOUR> resource Id from an attribute such as R.attr.message_sent_text_color etc.
-        fun getColorResourceIdFromAttr(context: Context, attr: Int): Int {
-            val typedValue = TypedValue()
-            context.theme.resolveAttribute(attr, typedValue, true)
-            return typedValue.resourceId
-        }
     }
     // endregion
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/utilities/MentionUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/utilities/MentionUtilities.kt
@@ -13,11 +13,10 @@ import nl.komponents.kovenant.combine.Tuple2
 import org.session.libsession.messaging.contacts.Contact
 import org.session.libsession.messaging.utilities.SodiumUtilities
 import org.session.libsession.utilities.TextSecurePreferences
-import org.thoughtcrime.securesms.conversation.v2.messages.VisibleMessageContentView.Companion.getColorResourceIdFromAttr
-import org.thoughtcrime.securesms.conversation.v2.messages.VisibleMessageContentView.Companion.getMessageTextColourAttr
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
-import org.thoughtcrime.securesms.util.UiModeUtilities
 import org.thoughtcrime.securesms.util.getAccentColor
+import org.thoughtcrime.securesms.util.getColorResourceIdFromAttr
+import org.thoughtcrime.securesms.util.getMessageTextColourAttr
 import java.util.regex.Pattern
 
 object MentionUtilities {
@@ -60,7 +59,8 @@ object MentionUtilities {
             }
         }
         val result = SpannableString(text)
-        val isLightMode = UiModeUtilities.isDayUiMode(context)
+
+        // Specify colour of mention text
         val color = if (isOutgoingMessage) {
             val mentionTextColourAttributeId = getMessageTextColourAttr(true)
             val mentionTextColourResourceId  = getColorResourceIdFromAttr(context, mentionTextColourAttributeId)
@@ -68,6 +68,7 @@ object MentionUtilities {
         } else {
             context.getAccentColor()
         }
+
         for (mention in mentions) {
             result.setSpan(ForegroundColorSpan(color), mention.first.lower, mention.first.upper, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
             result.setSpan(StyleSpan(Typeface.BOLD), mention.first.lower, mention.first.upper, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/utilities/MentionUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/utilities/MentionUtilities.kt
@@ -62,12 +62,8 @@ object MentionUtilities {
         val result = SpannableString(text)
         val isLightMode = UiModeUtilities.isDayUiMode(context)
         val color = if (isOutgoingMessage) {
-
-            val mentionTextColourAttributeId = getMessageTextColourAttr(isOutgoingMessage)
+            val mentionTextColourAttributeId = getMessageTextColourAttr(true)
             val mentionTextColourResourceId  = getColorResourceIdFromAttr(context, mentionTextColourAttributeId)
-            //context.theme.get
-
-            ResourcesCompat.getColor(context.resources, if (isLightMode) R.color.white else R.color.black, context.theme)
             ResourcesCompat.getColor(context.resources, mentionTextColourResourceId, context.theme)
         } else {
             context.getAccentColor()

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/utilities/MentionUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/utilities/MentionUtilities.kt
@@ -4,16 +4,21 @@ import android.content.Context
 import android.graphics.Typeface
 import android.text.Spannable
 import android.text.SpannableString
+import android.text.style.BackgroundColorSpan
 import android.text.style.ForegroundColorSpan
 import android.text.style.StyleSpan
 import android.util.Range
+import androidx.appcompat.widget.ThemeUtils
 import androidx.core.content.res.ResourcesCompat
 import network.loki.messenger.R
 import nl.komponents.kovenant.combine.Tuple2
 import org.session.libsession.messaging.contacts.Contact
 import org.session.libsession.messaging.utilities.SodiumUtilities
 import org.session.libsession.utilities.TextSecurePreferences
+import org.session.libsession.utilities.ThemeUtil
+import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
+import org.thoughtcrime.securesms.util.UiModeUtilities
 import org.thoughtcrime.securesms.util.getAccentColor
 import org.thoughtcrime.securesms.util.getColorResourceIdFromAttr
 import org.thoughtcrime.securesms.util.getMessageTextColourAttr
@@ -60,18 +65,36 @@ object MentionUtilities {
         }
         val result = SpannableString(text)
 
-        // Specify colour of mention text
-        val color = if (isOutgoingMessage) {
-            val mentionTextColourAttributeId = getMessageTextColourAttr(true)
-            val mentionTextColourResourceId  = getColorResourceIdFromAttr(context, mentionTextColourAttributeId)
-            ResourcesCompat.getColor(context.resources, mentionTextColourResourceId, context.theme)
-        } else {
-            context.getAccentColor()
+        var mentionTextColour: Int? = null
+        // In dark themes..
+        if (ThemeUtil.isDarkTheme(context)) {
+            // ..we use the standard outgoing message colour for outgoing messages..
+            if (isOutgoingMessage) {
+                val mentionTextColourAttributeId = getMessageTextColourAttr(true)
+                val mentionTextColourResourceId = getColorResourceIdFromAttr(context, mentionTextColourAttributeId)
+                mentionTextColour = ResourcesCompat.getColor(context.resources, mentionTextColourResourceId, context.theme)
+            }
+            else // ..but we use the accent colour for incoming messages (i.e., someone mentioning us)..
+            {
+                mentionTextColour = context.getAccentColor()
+            }
+        }
+        else // ..while in light themes we always just use the incoming or outgoing message text colour for mentions.
+        {
+            val mentionTextColourAttributeId = getMessageTextColourAttr(isOutgoingMessage)
+            val mentionTextColourResourceId = getColorResourceIdFromAttr(context, mentionTextColourAttributeId)
+            mentionTextColour = ResourcesCompat.getColor(context.resources, mentionTextColourResourceId, context.theme)
         }
 
         for (mention in mentions) {
-            result.setSpan(ForegroundColorSpan(color), mention.first.lower, mention.first.upper, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            result.setSpan(ForegroundColorSpan(mentionTextColour), mention.first.lower, mention.first.upper, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
             result.setSpan(StyleSpan(Typeface.BOLD), mention.first.lower, mention.first.upper, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+
+            // If we're using a light theme then we change the background colour of the mention to be the accent colour
+            if (ThemeUtil.isLightTheme(context)) {
+                val backgroundColour = context.getAccentColor();
+                result.setSpan(BackgroundColorSpan(backgroundColour), mention.first.lower, mention.first.upper, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+            }
         }
         return result
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/utilities/MentionUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/utilities/MentionUtilities.kt
@@ -13,6 +13,8 @@ import nl.komponents.kovenant.combine.Tuple2
 import org.session.libsession.messaging.contacts.Contact
 import org.session.libsession.messaging.utilities.SodiumUtilities
 import org.session.libsession.utilities.TextSecurePreferences
+import org.thoughtcrime.securesms.conversation.v2.messages.VisibleMessageContentView.Companion.getColorResourceIdFromAttr
+import org.thoughtcrime.securesms.conversation.v2.messages.VisibleMessageContentView.Companion.getMessageTextColourAttr
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
 import org.thoughtcrime.securesms.util.UiModeUtilities
 import org.thoughtcrime.securesms.util.getAccentColor
@@ -60,7 +62,13 @@ object MentionUtilities {
         val result = SpannableString(text)
         val isLightMode = UiModeUtilities.isDayUiMode(context)
         val color = if (isOutgoingMessage) {
+
+            val mentionTextColourAttributeId = getMessageTextColourAttr(isOutgoingMessage)
+            val mentionTextColourResourceId  = getColorResourceIdFromAttr(context, mentionTextColourAttributeId)
+            //context.theme.get
+
             ResourcesCompat.getColor(context.resources, if (isLightMode) R.color.white else R.color.black, context.theme)
+            ResourcesCompat.getColor(context.resources, mentionTextColourResourceId, context.theme)
         } else {
             context.getAccentColor()
         }

--- a/app/src/main/java/org/thoughtcrime/securesms/util/ViewUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/ViewUtilities.kt
@@ -70,7 +70,6 @@ fun View.hideKeyboard() {
     imm.hideSoftInputFromWindow(this.windowToken, 0)
 }
 
-
 fun View.drawToBitmap(config: Bitmap.Config = Bitmap.Config.ARGB_8888, longestWidth: Int = 2000): Bitmap {
     val size = Size(measuredWidth, measuredHeight).coerceAtMost(longestWidth)
     val scale = size.width / measuredWidth.toFloat()

--- a/app/src/main/java/org/thoughtcrime/securesms/util/ViewUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/ViewUtilities.kt
@@ -9,12 +9,15 @@ import android.graphics.Bitmap
 import android.graphics.PointF
 import android.graphics.Rect
 import android.util.Size
+import android.util.TypedValue
 import android.view.View
 import androidx.annotation.ColorInt
 import androidx.annotation.DimenRes
 import network.loki.messenger.R
 import org.session.libsession.utilities.getColorFromAttr
 import android.view.inputmethod.InputMethodManager
+import androidx.annotation.AttrRes
+import androidx.annotation.ColorRes
 import androidx.core.graphics.applyCanvas
 import kotlin.math.roundToInt
 
@@ -31,6 +34,20 @@ val View.hitRect: Rect
 
 @ColorInt
 fun Context.getAccentColor() = getColorFromAttr(R.attr.colorAccent)
+
+// Method to grab the appropriate attribute for a message colour.
+// Note: This is an attribute, NOT a resource Id - see `getColorResourceIdFromAttr` for that.
+@AttrRes
+fun getMessageTextColourAttr(messageIsOutgoing: Boolean): Int =
+    if (messageIsOutgoing) R.attr.message_sent_text_color else R.attr.message_received_text_color
+
+// Method to get an actual R.id.<SOME_COLOUR> resource Id from an attribute such as R.attr.message_sent_text_color etc.
+@ColorRes
+fun getColorResourceIdFromAttr(context: Context, attr: Int): Int {
+    val typedValue = TypedValue()
+    context.theme.resolveAttribute(attr, typedValue, true)
+    return typedValue.resourceId
+}
 
 fun View.animateSizeChange(@DimenRes startSizeID: Int, @DimenRes endSizeID: Int, animationDuration: Long = 250) {
     val startSize = resources.getDimension(startSizeID)

--- a/libsession/src/main/java/org/session/libsession/messaging/mentions/MentionsManager.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/mentions/MentionsManager.kt
@@ -2,7 +2,7 @@ package org.session.libsession.messaging.mentions
 
 import org.session.libsession.messaging.MessagingModuleConfiguration
 import org.session.libsession.messaging.contacts.Contact
-import java.util.*
+import java.util.Locale
 
 object MentionsManager {
     var userPublicKeyCache = mutableMapOf<Long, Set<String>>() // Thread ID to set of user hex encoded public keys

--- a/libsession/src/main/java/org/session/libsession/utilities/ThemeUtil.java
+++ b/libsession/src/main/java/org/session/libsession/utilities/ThemeUtil.java
@@ -27,6 +27,10 @@ public class ThemeUtil {
     return getAttributeText(context, R.attr.theme_type, "light").equals("dark");
   }
 
+  public static boolean isLightTheme(@NonNull Context context) {
+    return getAttributeText(context, R.attr.theme_type, "light").equals("light");
+  }
+
   public static boolean getThemedBoolean(@NonNull Context context, @AttrRes int attr) {
     TypedValue      typedValue = new TypedValue();
     Resources.Theme theme      = context.getTheme();


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Virtual Android 9 - API 28
 * Virtual Android 14 - API 34
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------
Fixes the mentions text colour in closed-groups and 1-on-1 to use the relevant outgoing or incoming message colour based on the user's current theme.

Test by mentioning users in closed-groups, communities, or 1-on-1 messages (the latter doesn't seem to make sense but that's a ticket for another time) and observing the text colour of mentions (i.e. "Hi to @Alice - how's it going?" - where you select your contact "Alice" from the drop-down on mention contacts that appears).