### PR TITLE
[SES-1755] Fix multiple quote previews

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/input_bar/InputBar.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/input_bar/InputBar.kt
@@ -140,6 +140,8 @@ class InputBar : RelativeLayout, InputBarEditTextDelegate, QuoteViewDelegate, Li
     }
 
     fun draftQuote(thread: Recipient, message: MessageRecord, glide: GlideRequests) {
+        quoteView?.let(binding.inputBarAdditionalContentContainer::removeView)
+
         quote = message
 
         // If we already have a link preview View then clear the 'additional content' layout so that


### PR DESCRIPTION
If you reply to a message while a reply preview is visible, the old preview is not removed.

<img width="340" alt="Screen Shot 2024-04-12 at 11 59 53 pm" src="https://github.com/oxen-io/session-android/assets/9282178/90e1ddbc-f7ec-4b62-82ad-403782970780">
