### PR TITLE
[SES-1754] Fix message menu icons not visible in light theme

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/menu/ContextMenuList.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/menu/ContextMenuList.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import network.loki.messenger.R
+import org.session.libsession.utilities.getColorFromAttr
 import org.thoughtcrime.securesms.util.adapter.mapping.LayoutFactory
 import org.thoughtcrime.securesms.util.adapter.mapping.MappingAdapter
 import org.thoughtcrime.securesms.util.adapter.mapping.MappingModel
@@ -84,7 +85,7 @@ class ContextMenuList(recyclerView: RecyclerView, onItemClick: () -> Unit) {
         context.theme.resolveAttribute(item.iconRes, typedValue, true)
         icon.setImageDrawable(ContextCompat.getDrawable(context, typedValue.resourceId))
 
-        icon.imageTintList = color?.let(ColorStateList::valueOf)
+        icon.imageTintList = ColorStateList.valueOf(color ?: context.getColorFromAttr(android.R.attr.textColor))
       }
       item.contentDescription?.let(context.resources::getString)?.let { itemView.contentDescription = it }
       title.setText(item.title)


### PR DESCRIPTION
# before

<img width="180" alt="Screen Shot 2024-04-13 at 12 11 12 am" src="https://github.com/oxen-io/session-android/assets/9282178/3c15c776-62bd-4eb3-9cda-f8234b07bbfb">

# after

<img width="175" alt="Screen Shot 2024-04-13 at 12 25 23 am" src="https://github.com/oxen-io/session-android/assets/9282178/8d4c2b69-4594-4734-aec4-f86fd9c7945b">
