### PR TITLE
SES1628 - Add git commit details to version info

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -105,6 +105,7 @@ android {
         project.ext.set("archivesBaseName", "session")
 
         buildConfigField "long", "BUILD_TIMESTAMP", getLastCommitTimestamp() + "L"
+        buildConfigField "String", "GIT_HASH", "\"$getGitHash\""
         buildConfigField "String", "CONTENT_PROXY_HOST", "\"contentproxy.signal.org\""
         buildConfigField "int", "CONTENT_PROXY_PORT", "443"
         buildConfigField "String", "USER_AGENT", "\"OWA\""
@@ -131,13 +132,11 @@ android {
     buildTypes {
         release {
             minifyEnabled false
-            resValue("string", "git_hash", getGitHash())
         }
         debug {
             isDefault true
             minifyEnabled false
             enableUnitTestCoverage true
-            resValue("string", "git_hash", getGitHash())
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,17 @@ def abiPostFix = ['armeabi-v7a' : 1,
                   'x86_64'      : 4,
                   'universal'   : 5]
 
+// Function to get the current git commit hash so we can embed it along w/ the build version.
+// Note: This is visible in the SettingsActivity, right at the bottom (R.id.versionTextView).
+def getGitHash = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine "git", "rev-parse", "--short", "HEAD"
+        standardOutput = stdout
+    }
+    return stdout.toString().trim()
+}
+
 android {
     compileSdkVersion androidCompileSdkVersion
     namespace 'network.loki.messenger'
@@ -120,11 +131,13 @@ android {
     buildTypes {
         release {
             minifyEnabled false
+            resValue("string", "git_hash", getGitHash())
         }
         debug {
             isDefault true
             minifyEnabled false
             enableUnitTestCoverage true
+            resValue("string", "git_hash", getGitHash())
         }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsActivity.kt
@@ -109,8 +109,8 @@ class SettingsActivity : PassphraseRequiredActionBarActivity() {
             seedButton.setOnClickListener { showSeed() }
             clearAllDataButton.setOnClickListener { clearAllData() }
 
-            val gitCommitFirstSix = getString(R.string.git_hash).take(6)
-            versionTextView.text = String.format(getString(R.string.version_s), "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE} - $gitCommitFirstSix)")
+            val gitCommitFirstSixChars = BuildConfig.GIT_HASH.take(6)
+            versionTextView.text = String.format(getString(R.string.version_s), "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE} - $gitCommitFirstSixChars)")
         }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsActivity.kt
@@ -37,6 +37,7 @@ import org.session.libsession.snode.SnodeAPI
 import org.session.libsession.utilities.*
 import org.session.libsession.utilities.SSKEnvironment.ProfileManagerProtocol
 import org.session.libsession.utilities.recipients.Recipient
+import org.session.libsignal.utilities.getProperty
 import org.thoughtcrime.securesms.PassphraseRequiredActionBarActivity
 import org.thoughtcrime.securesms.avatar.AvatarSelection
 import org.thoughtcrime.securesms.components.ProfilePictureView
@@ -107,7 +108,9 @@ class SettingsActivity : PassphraseRequiredActionBarActivity() {
             helpButton.setOnClickListener { showHelp() }
             seedButton.setOnClickListener { showSeed() }
             clearAllDataButton.setOnClickListener { clearAllData() }
-            versionTextView.text = String.format(getString(R.string.version_s), "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})")
+
+            val gitCommitFirstSix = getString(R.string.git_hash).take(6)
+            versionTextView.text = String.format(getString(R.string.version_s), "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE} - $gitCommitFirstSix)")
         }
     }
 

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -7,7 +7,7 @@
     <string name="ban">مسدود</string>
     <string name="save">ذخیره</string>
     <string name="note_to_self">یادداشت به خود</string>
-    <string name="version_s">نسخه</string>
+    <string name="version_s">%s نسخه</string>
     <!-- AbstractNotificationBuilder -->
     <string name="AbstractNotificationBuilder_new_message">پیام جدید</string>
     <!-- AlbumThumbnailView -->


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have tested my contribution on these devices:
 * Virtual Pixel 3a, Android 14 API 34
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Adds the first 6 chars of the current git commit hash used to build the app to the "Version: [foo]" details in the Settings activity.
