### PR TITLE
[SES-1732] Fix multiple link previews

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/input_bar/InputBar.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/input_bar/InputBar.kt
@@ -178,7 +178,7 @@ class InputBar : RelativeLayout, InputBarEditTextDelegate, QuoteViewDelegate, Li
         // message we'll bail early if a link preview View already exists and just let
         // `updateLinkPreview` get called to update the existing View.
         if (linkPreview != null && linkPreviewDraftView != null) return
-
+        linkPreviewDraftView?.let(binding.inputBarAdditionalContentContainer::removeView)
         linkPreviewDraftView = LinkPreviewDraftView(context).also { it.delegate = this }
 
         // Add the link preview View. Note: If there's already a quote View in the 'additional


### PR DESCRIPTION
tracked internally: https://optf.atlassian.net/browse/SES-1732

Getting a loading animation bug when trying to send a link with a preview attached but the loading animation doesn’t go away and the link preview doesn’t work at first, take a couple of tries to get preview to load