### PR TITLE
[SES-1733] Fix group expiration update messages

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -31,6 +31,7 @@ import org.session.libsession.messaging.utilities.UpdateMessageData;
 import org.session.libsession.utilities.IdentityKeyMismatch;
 import org.session.libsession.utilities.NetworkFailure;
 import org.session.libsession.utilities.recipients.Recipient;
+import org.thoughtcrime.securesms.dependencies.DatabaseComponent;
 
 import java.util.List;
 import java.util.Objects;
@@ -120,7 +121,8 @@ public abstract class MessageRecord extends DisplayRecord {
       return new SpannableString(UpdateMessageBuilder.INSTANCE.buildGroupUpdateMessage(context, updateMessageData, getIndividualRecipient().getAddress().serialize(), isOutgoing()));
     } else if (isExpirationTimerUpdate()) {
       int seconds = (int) (getExpiresIn() / 1000);
-      return new SpannableString(UpdateMessageBuilder.INSTANCE.buildExpirationTimerMessage(context, seconds, getRecipient(), getIndividualRecipient().getAddress().serialize(), isOutgoing(), getTimestamp(), expireStarted));
+      boolean isGroup = DatabaseComponent.get(context).threadDatabase().getRecipientForThreadId(getThreadId()).isGroupRecipient();
+      return new SpannableString(UpdateMessageBuilder.INSTANCE.buildExpirationTimerMessage(context, seconds, isGroup, getIndividualRecipient().getAddress().serialize(), isOutgoing(), getTimestamp(), expireStarted));
     } else if (isDataExtractionNotification()) {
       if (isScreenshotNotification()) return new SpannableString((UpdateMessageBuilder.INSTANCE.buildDataExtractionMessage(context, DataExtractionNotificationInfoMessage.Kind.SCREENSHOT, getIndividualRecipient().getAddress().serialize())));
       else if (isMediaSavedNotification()) return new SpannableString((UpdateMessageBuilder.INSTANCE.buildDataExtractionMessage(context, DataExtractionNotificationInfoMessage.Kind.MEDIA_SAVED, getIndividualRecipient().getAddress().serialize())));

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/MarkReadReceiver.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/MarkReadReceiver.kt
@@ -61,11 +61,15 @@ class MarkReadReceiver : BroadcastReceiver() {
 
             val mmsSmsDatabase = DatabaseComponent.get(context).mmsSmsDatabase()
 
+            val threadDb = DatabaseComponent.get(context).threadDatabase()
+
             // start disappear after read messages except TimerUpdates in groups.
             markedReadMessages
                 .filter { it.expiryType == ExpiryType.AFTER_READ }
                 .map { it.syncMessageId }
-                .filter { mmsSmsDatabase.getMessageForTimestamp(it.timetamp)?.run { isExpirationTimerUpdate && recipient.isClosedGroupRecipient } == false }
+                .filter { mmsSmsDatabase.getMessageForTimestamp(it.timetamp)?.run {
+                    isExpirationTimerUpdate && threadDb.getRecipientForThreadId(threadId)?.isGroupRecipient == true } == false
+                }
                 .forEach { messageExpirationManager.startDisappearAfterRead(it.timetamp, it.address.serialize()) }
 
             hashToDisappearAfterReadMessage(context, markedReadMessages)?.let {

--- a/app/src/main/java/org/thoughtcrime/securesms/service/ExpiringMessageManager.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/ExpiringMessageManager.kt
@@ -151,8 +151,8 @@ class ExpiringMessageManager(context: Context) : MessageExpirationManagerProtoco
 
         val userPublicKey = getLocalNumber(context)
         val senderPublicKey = message.sender
-        val sentTimestamp = if (message.sentTimestamp == null) 0 else message.sentTimestamp!!
-        val expireStartedAt = if (expiryMode is AfterSend || message.isSenderSelf) sentTimestamp else 0
+        val sentTimestamp = message.sentTimestamp ?: 0
+        val expireStartedAt = if ((expiryMode is AfterSend || message.isSenderSelf) && !message.isGroup) sentTimestamp else 0
 
         // Notify the user
         if (senderPublicKey == null || userPublicKey == senderPublicKey) {

--- a/app/src/main/res/layout/view_control_message.xml
+++ b/app/src/main/res/layout/view_control_message.xml
@@ -48,7 +48,7 @@
         android:textColor="?android:textColorPrimary"
         android:textSize="@dimen/very_small_font_size"
         android:textStyle="bold"
-        tools:text="@string/MessageRecord_you_disabled_disappearing_messages" />
+        tools:text="You disabled disappearing messages" />
 
     <FrameLayout
         android:id="@+id/call_view"

--- a/libsession/src/main/java/org/session/libsession/messaging/utilities/UpdateMessageBuilder.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/utilities/UpdateMessageBuilder.kt
@@ -10,7 +10,6 @@ import org.session.libsession.messaging.calls.CallMessageType.CALL_INCOMING
 import org.session.libsession.messaging.calls.CallMessageType.CALL_MISSED
 import org.session.libsession.messaging.calls.CallMessageType.CALL_OUTGOING
 import org.session.libsession.messaging.contacts.Contact
-import org.session.libsession.messaging.messages.ExpirationConfiguration.Companion.isNewConfigEnabled
 import org.session.libsession.messaging.sending_receiving.data_extraction.DataExtractionNotificationInfoMessage
 import org.session.libsession.utilities.ExpirationUtil
 import org.session.libsession.utilities.getExpirationTypeDisplayValue
@@ -90,25 +89,21 @@ object UpdateMessageBuilder {
         val senderName = if (isOutgoing) context.getString(R.string.MessageRecord_you) else getSenderName(senderId!!)
         return if (duration <= 0) {
             if (isOutgoing) {
-                if (!isNewConfigEnabled) context.getString(R.string.MessageRecord_you_disabled_disappearing_messages)
-                else context.getString(if (recipient.is1on1) R.string.MessageRecord_you_turned_off_disappearing_messages_1_on_1 else R.string.MessageRecord_you_turned_off_disappearing_messages)
+                context.getString(if (recipient.is1on1) R.string.MessageRecord_you_turned_off_disappearing_messages_1_on_1 else R.string.MessageRecord_you_turned_off_disappearing_messages)
             } else {
-                if (!isNewConfigEnabled) context.getString(R.string.MessageRecord_s_disabled_disappearing_messages, senderName)
-                else context.getString(if (recipient.is1on1) R.string.MessageRecord_s_turned_off_disappearing_messages_1_on_1 else R.string.MessageRecord_s_turned_off_disappearing_messages, senderName)
+                context.getString(if (recipient.is1on1) R.string.MessageRecord_s_turned_off_disappearing_messages_1_on_1 else R.string.MessageRecord_s_turned_off_disappearing_messages, senderName)
             }
         } else {
             val time = ExpirationUtil.getExpirationDisplayValue(context, duration.toInt())
             val action = context.getExpirationTypeDisplayValue(timestamp == expireStarted)
             if (isOutgoing) {
-                if (!isNewConfigEnabled) context.getString(R.string.MessageRecord_you_set_disappearing_message_time_to_s, time)
-                else context.getString(
+                context.getString(
                     if (recipient.is1on1) R.string.MessageRecord_you_set_messages_to_disappear_s_after_s_1_on_1 else R.string.MessageRecord_you_set_messages_to_disappear_s_after_s,
                     time,
                     action
                 )
             } else {
-                if (!isNewConfigEnabled) context.getString(R.string.MessageRecord_s_set_disappearing_message_time_to_s, senderName, time)
-                else context.getString(
+                context.getString(
                     if (recipient.is1on1) R.string.MessageRecord_s_set_messages_to_disappear_s_after_s_1_on_1 else R.string.MessageRecord_s_set_messages_to_disappear_s_after_s,
                     senderName,
                     time,

--- a/libsession/src/main/java/org/session/libsession/messaging/utilities/UpdateMessageBuilder.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/utilities/UpdateMessageBuilder.kt
@@ -81,7 +81,7 @@ object UpdateMessageBuilder {
             else context.getString(if (isGroup) R.string.MessageRecord_s_turned_off_disappearing_messages else R.string.MessageRecord_s_turned_off_disappearing_messages_1_on_1, senderName)
         } else {
             val time = ExpirationUtil.getExpirationDisplayValue(context, duration.toInt())
-            val action = context.getExpirationTypeDisplayValue(timestamp == expireStarted)
+            val action = context.getExpirationTypeDisplayValue(timestamp >= expireStarted)
             if (isOutgoing) context.getString(
                 if (isGroup) R.string.MessageRecord_you_set_messages_to_disappear_s_after_s else R.string.MessageRecord_you_set_messages_to_disappear_s_after_s_1_on_1,
                 time,

--- a/libsession/src/main/java/org/session/libsession/messaging/utilities/UpdateMessageBuilder.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/utilities/UpdateMessageBuilder.kt
@@ -11,9 +11,10 @@ import org.session.libsession.messaging.calls.CallMessageType.CALL_MISSED
 import org.session.libsession.messaging.calls.CallMessageType.CALL_OUTGOING
 import org.session.libsession.messaging.contacts.Contact
 import org.session.libsession.messaging.sending_receiving.data_extraction.DataExtractionNotificationInfoMessage
+import org.session.libsession.messaging.sending_receiving.data_extraction.DataExtractionNotificationInfoMessage.Kind.MEDIA_SAVED
+import org.session.libsession.messaging.sending_receiving.data_extraction.DataExtractionNotificationInfoMessage.Kind.SCREENSHOT
 import org.session.libsession.utilities.ExpirationUtil
 import org.session.libsession.utilities.getExpirationTypeDisplayValue
-import org.session.libsession.utilities.recipients.Recipient
 import org.session.libsession.utilities.truncateIdForDisplay
 
 object UpdateMessageBuilder {
@@ -30,47 +31,35 @@ object UpdateMessageBuilder {
         else getSenderName(senderId!!)
 
         return when (updateData) {
-            is UpdateMessageData.Kind.GroupCreation -> if (isOutgoing) {
-                context.getString(R.string.MessageRecord_you_created_a_new_group)
-            } else {
-                context.getString(R.string.MessageRecord_s_added_you_to_the_group, senderName)
+            is UpdateMessageData.Kind.GroupCreation -> {
+                if (isOutgoing) context.getString(R.string.MessageRecord_you_created_a_new_group)
+                else context.getString(R.string.MessageRecord_s_added_you_to_the_group, senderName)
             }
-            is UpdateMessageData.Kind.GroupNameChange -> if (isOutgoing) {
-                context.getString(R.string.MessageRecord_you_renamed_the_group_to_s, updateData.name)
-            } else {
-                context.getString(R.string.MessageRecord_s_renamed_the_group_to_s, senderName, updateData.name)
+            is UpdateMessageData.Kind.GroupNameChange -> {
+                if (isOutgoing) context.getString(R.string.MessageRecord_you_renamed_the_group_to_s, updateData.name)
+                else context.getString(R.string.MessageRecord_s_renamed_the_group_to_s, senderName, updateData.name)
             }
             is UpdateMessageData.Kind.GroupMemberAdded -> {
                 val members = updateData.updatedMembers.joinToString(", ", transform = ::getSenderName)
-                if (isOutgoing) {
-                    context.getString(R.string.MessageRecord_you_added_s_to_the_group, members)
-                } else {
-                    context.getString(R.string.MessageRecord_s_added_s_to_the_group, senderName, members)
-                }
+                if (isOutgoing) context.getString(R.string.MessageRecord_you_added_s_to_the_group, members)
+                else context.getString(R.string.MessageRecord_s_added_s_to_the_group, senderName, members)
             }
             is UpdateMessageData.Kind.GroupMemberRemoved -> {
                 val userPublicKey = storage.getUserPublicKey()!!
                 // 1st case: you are part of the removed members
                 return if (userPublicKey in updateData.updatedMembers) {
-                    if (isOutgoing) {
-                        context.getString(R.string.MessageRecord_left_group)
-                    } else {
-                        context.getString(R.string.MessageRecord_you_were_removed_from_the_group)
-                    }
+                    if (isOutgoing) context.getString(R.string.MessageRecord_left_group)
+                    else context.getString(R.string.MessageRecord_you_were_removed_from_the_group)
                 } else {
                     // 2nd case: you are not part of the removed members
                     val members = updateData.updatedMembers.joinToString(", ", transform = ::getSenderName)
-                    if (isOutgoing) {
-                        context.getString(R.string.MessageRecord_you_removed_s_from_the_group, members)
-                    } else {
-                        context.getString(R.string.MessageRecord_s_removed_s_from_the_group, senderName, members)
-                    }
+                    if (isOutgoing) context.getString(R.string.MessageRecord_you_removed_s_from_the_group, members)
+                    else context.getString(R.string.MessageRecord_s_removed_s_from_the_group, senderName, members)
                 }
             }
-            is UpdateMessageData.Kind.GroupMemberLeft -> if (isOutgoing) {
-                context.getString(R.string.MessageRecord_left_group)
-            } else {
-                context.getString(R.string.ConversationItem_group_action_left, senderName)
+            is UpdateMessageData.Kind.GroupMemberLeft -> {
+                if (isOutgoing) context.getString(R.string.MessageRecord_left_group)
+                else context.getString(R.string.ConversationItem_group_action_left, senderName)
             }
             else -> return ""
         }
@@ -79,7 +68,7 @@ object UpdateMessageBuilder {
     fun buildExpirationTimerMessage(
         context: Context,
         duration: Long,
-        recipient: Recipient,
+        isGroup: Boolean,
         senderId: String? = null,
         isOutgoing: Boolean = false,
         timestamp: Long,
@@ -88,40 +77,28 @@ object UpdateMessageBuilder {
         if (!isOutgoing && senderId == null) return ""
         val senderName = if (isOutgoing) context.getString(R.string.MessageRecord_you) else getSenderName(senderId!!)
         return if (duration <= 0) {
-            if (isOutgoing) {
-                context.getString(if (recipient.is1on1) R.string.MessageRecord_you_turned_off_disappearing_messages_1_on_1 else R.string.MessageRecord_you_turned_off_disappearing_messages)
-            } else {
-                context.getString(if (recipient.is1on1) R.string.MessageRecord_s_turned_off_disappearing_messages_1_on_1 else R.string.MessageRecord_s_turned_off_disappearing_messages, senderName)
-            }
+            if (isOutgoing) context.getString(if (isGroup) R.string.MessageRecord_you_turned_off_disappearing_messages else R.string.MessageRecord_you_turned_off_disappearing_messages_1_on_1)
+            else context.getString(if (isGroup) R.string.MessageRecord_s_turned_off_disappearing_messages else R.string.MessageRecord_s_turned_off_disappearing_messages_1_on_1, senderName)
         } else {
             val time = ExpirationUtil.getExpirationDisplayValue(context, duration.toInt())
             val action = context.getExpirationTypeDisplayValue(timestamp == expireStarted)
-            if (isOutgoing) {
-                context.getString(
-                    if (recipient.is1on1) R.string.MessageRecord_you_set_messages_to_disappear_s_after_s_1_on_1 else R.string.MessageRecord_you_set_messages_to_disappear_s_after_s,
-                    time,
-                    action
-                )
-            } else {
-                context.getString(
-                    if (recipient.is1on1) R.string.MessageRecord_s_set_messages_to_disappear_s_after_s_1_on_1 else R.string.MessageRecord_s_set_messages_to_disappear_s_after_s,
-                    senderName,
-                    time,
-                    action
-                )
-            }
+            if (isOutgoing) context.getString(
+                if (isGroup) R.string.MessageRecord_you_set_messages_to_disappear_s_after_s else R.string.MessageRecord_you_set_messages_to_disappear_s_after_s_1_on_1,
+                time,
+                action
+            ) else context.getString(
+                if (isGroup) R.string.MessageRecord_s_set_messages_to_disappear_s_after_s else R.string.MessageRecord_s_set_messages_to_disappear_s_after_s_1_on_1,
+                senderName,
+                time,
+                action
+            )
         }
     }
 
-    fun buildDataExtractionMessage(context: Context, kind: DataExtractionNotificationInfoMessage.Kind, senderId: String? = null): String {
-        val senderName = getSenderName(senderId!!)
-        return when (kind) {
-            DataExtractionNotificationInfoMessage.Kind.SCREENSHOT ->
-                context.getString(R.string.MessageRecord_s_took_a_screenshot, senderName)
-            DataExtractionNotificationInfoMessage.Kind.MEDIA_SAVED ->
-                context.getString(R.string.MessageRecord_media_saved_by_s, senderName)
-        }
-    }
+    fun buildDataExtractionMessage(context: Context, kind: DataExtractionNotificationInfoMessage.Kind, senderId: String? = null) = when (kind) {
+        SCREENSHOT -> R.string.MessageRecord_s_took_a_screenshot
+        MEDIA_SAVED -> R.string.MessageRecord_media_saved_by_s
+    }.let { context.getString(it, getSenderName(senderId!!)) }
 
     fun buildCallMessage(context: Context, type: CallMessageType, sender: String): String =
         when (type) {

--- a/libsession/src/main/res/values-fr-rFR/strings.xml
+++ b/libsession/src/main/res/values-fr-rFR/strings.xml
@@ -15,10 +15,6 @@
     <string name="MessageRecord_s_called_you">%s vous a appelé·e</string>
     <string name="MessageRecord_called_s">Vous avez appelé %s</string>
     <string name="MessageRecord_missed_call_from">Appel manqué de %s</string>
-    <string name="MessageRecord_you_disabled_disappearing_messages">Vous avez désactivé les messages éphémères.</string>
-    <string name="MessageRecord_s_disabled_disappearing_messages">%1$s a désactivé les messages éphémères.</string>
-    <string name="MessageRecord_you_set_disappearing_message_time_to_s">Vous avez défini l’expiration des messages éphémères à %1$s</string>
-    <string name="MessageRecord_s_set_disappearing_message_time_to_s">%1$s a défini l’expiration des messages éphémères à %2$s</string>
     <string name="MessageRecord_s_took_a_screenshot">%1$s a pris une capture d\'écran.</string>
     <string name="MessageRecord_media_saved_by_s">%1$s a enregistré le média.</string>
     <!-- expiration -->

--- a/libsession/src/main/res/values-fr/strings.xml
+++ b/libsession/src/main/res/values-fr/strings.xml
@@ -15,10 +15,6 @@
     <string name="MessageRecord_s_called_you">%s vous a appelé·e</string>
     <string name="MessageRecord_called_s">Vous avez appelé %s</string>
     <string name="MessageRecord_missed_call_from">Appel manqué de %s</string>
-    <string name="MessageRecord_you_disabled_disappearing_messages">Vous avez désactivé les messages éphémères.</string>
-    <string name="MessageRecord_s_disabled_disappearing_messages">%1$s a désactivé les messages éphémères.</string>
-    <string name="MessageRecord_you_set_disappearing_message_time_to_s">Vous avez défini l’expiration des messages éphémères à %1$s</string>
-    <string name="MessageRecord_s_set_disappearing_message_time_to_s">%1$s a défini l’expiration des messages éphémères à %2$s</string>
     <string name="MessageRecord_s_took_a_screenshot">%1$s a pris une capture d\'écran.</string>
     <string name="MessageRecord_media_saved_by_s">%1$s a enregistré le média.</string>
     <!-- expiration -->

--- a/libsession/src/main/res/values/strings.xml
+++ b/libsession/src/main/res/values/strings.xml
@@ -17,17 +17,13 @@
     <string name="MessageRecord_missed_call_from">Missed call from %s</string>
     <string name="MessageRecord_follow_setting">Follow Setting</string>
     <string name="AccessibilityId_follow_setting">Follow setting</string>
-    <string name="MessageRecord_you_disabled_disappearing_messages">You disabled disappearing messages.</string>
     <string name="MessageRecord_you_turned_off_disappearing_messages">You have turned off disappearing messages.</string>
     <string name="MessageRecord_you_turned_off_disappearing_messages_1_on_1">You turned off disappearing messages. Messages you send will no longer disappear.</string>
-    <string name="MessageRecord_s_disabled_disappearing_messages">%1$s disabled disappearing messages.</string>
     <string name="MessageRecord_s_turned_off_disappearing_messages">%1$s turned off disappearing messages.</string>
     <string name="MessageRecord_s_turned_off_disappearing_messages_1_on_1">%1$s has turned off disappearing messages. Messages they send will no longer disappear.</string>
-    <string name="MessageRecord_you_set_disappearing_message_time_to_s">You set the disappearing message timer to %1$s</string>
     <string name="MessageRecord_you_set_messages_to_disappear_s_after_s">You have set messages to disappear %1$s after they have been %2$s</string>
     <string name="MessageRecord_you_set_messages_to_disappear_s_after_s_1_on_1">You set your messages to disappear %1$s after they have been %2$s.</string>
     <string name="MessageRecord_you_changed_messages_to_disappear_s_after_s">You have changed messages to disappear %1$s after they have been %2$s</string>
-    <string name="MessageRecord_s_set_disappearing_message_time_to_s">%1$s set the disappearing message timer to %2$s</string>
     <string name="MessageRecord_s_set_messages_to_disappear_s_after_s">%1$s has set messages to disappear %2$s after they have been %3$s</string>
     <string name="MessageRecord_s_set_messages_to_disappear_s_after_s_1_on_1">%1$s has set their messages to disappear %2$s after they have been %3$s.</string>
     <string name="MessageRecord_s_changed_messages_to_disappear_s_after_s">%1$s has changed messages to disappear %2$s after they have been %3$s</string>


### PR DESCRIPTION
This PR fixes a control message which was not correctly changed for groups.

This PR fixes one code path where timer expiration messages in groups would be scheduled for deletion (they are not supposed to be).

<img width="1029" alt="Screen Shot 2024-04-18 at 1 55 02 pm" src="https://github.com/oxen-io/session-android/assets/9282178/fc4018d1-155f-4f3b-946a-4ea7ae0b9ea8">
