### PR TITLE
[SES-1606] Request permission before call when permission is revoked

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/menus/ConversationMenuHelper.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/menus/ConversationMenuHelper.kt
@@ -37,9 +37,8 @@ import org.thoughtcrime.securesms.conversation.v2.utilities.NotificationUtils
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
 import org.thoughtcrime.securesms.groups.EditClosedGroupActivity
 import org.thoughtcrime.securesms.groups.EditClosedGroupActivity.Companion.groupIDKey
-import org.thoughtcrime.securesms.permissions.Permissions
+import org.thoughtcrime.securesms.permissions.requestMicrophonePermission
 import org.thoughtcrime.securesms.preferences.PrivacySettingsActivity
-import org.thoughtcrime.securesms.preferences.requestMicrophonePermission
 import org.thoughtcrime.securesms.service.WebRtcCallService
 import org.thoughtcrime.securesms.showMuteDialog
 import org.thoughtcrime.securesms.showSessionDialog

--- a/app/src/main/java/org/thoughtcrime/securesms/permissions/Permissions.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/permissions/Permissions.java
@@ -1,9 +1,7 @@
 package org.thoughtcrime.securesms.permissions;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
@@ -11,9 +9,7 @@ import android.os.Build;
 import android.provider.Settings;
 import android.util.DisplayMetrics;
 import android.view.Display;
-import android.view.ViewGroup;
 import android.view.WindowManager;
-import android.widget.Button;
 
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
@@ -32,8 +28,6 @@ import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-
-import network.loki.messenger.R;
 
 public class Permissions {
 

--- a/app/src/main/java/org/thoughtcrime/securesms/permissions/Permissions.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/permissions/Permissions.kt
@@ -1,0 +1,29 @@
+package org.thoughtcrime.securesms.permissions
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import androidx.fragment.app.Fragment
+import network.loki.messenger.R
+import org.session.libsession.utilities.TextSecurePreferences
+
+
+fun Fragment.requestMicrophonePermission(callback: (Boolean) -> Unit) {
+    requireContext().requestMicrophonePermission(Permissions.with(this), callback)
+}
+
+fun Activity.requestMicrophonePermission(callback: (Boolean) -> Unit) {
+    requestMicrophonePermission(Permissions.with(this), callback)
+}
+
+private fun Context.requestMicrophonePermission(
+    permissions: Permissions.PermissionsBuilder,
+    callback: (Boolean) -> Unit
+) {
+    permissions
+        .request(Manifest.permission.RECORD_AUDIO)
+        .withPermanentDenialDialog(getString(R.string.ConversationActivity_signal_requires_the_microphone_permission_in_order_to_send_audio_messages))
+        .onAllGranted { callback(true) }
+        .onAnyDenied { callback(false) }
+        .execute()
+}

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/CallToggleListener.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/CallToggleListener.kt
@@ -1,6 +1,8 @@
 package org.thoughtcrime.securesms.preferences
 
 import android.Manifest
+import android.app.Activity
+import android.content.Context
 import androidx.fragment.app.Fragment
 import androidx.preference.Preference
 import network.loki.messenger.R
@@ -10,36 +12,47 @@ import org.thoughtcrime.securesms.permissions.Permissions
 import org.thoughtcrime.securesms.showSessionDialog
 
 internal class CallToggleListener(
-    private val context: Fragment,
-    private val setCallback: (Boolean) -> Unit
+    private val fragment: Fragment,
+    private val callback: (Boolean) -> Unit
 ) : Preference.OnPreferenceChangeListener {
 
     override fun onPreferenceChange(preference: Preference, newValue: Any): Boolean {
         if (newValue == false) return true
 
         // check if we've shown the info dialog and check for microphone permissions
-        context.showSessionDialog {
+        fragment.showSessionDialog {
             title(R.string.dialog_voice_video_title)
             text(R.string.dialog_voice_video_message)
-            button(R.string.dialog_link_preview_enable_button_title, R.string.AccessibilityId_enable) { requestMicrophonePermission() }
+            button(R.string.dialog_link_preview_enable_button_title, R.string.AccessibilityId_enable) { fragment.requestMicrophonePermission(callback) }
             cancelButton()
         }
 
         return false
     }
+}
 
-    private fun requestMicrophonePermission() {
-        Permissions.with(context)
-            .request(Manifest.permission.RECORD_AUDIO)
-            .onAllGranted {
-                setBooleanPreference(
-                    context.requireContext(),
-                    TextSecurePreferences.CALL_NOTIFICATIONS_ENABLED,
-                    true
-                )
-                setCallback(true)
-            }
-            .onAnyDenied { setCallback(false) }
-            .execute()
-    }
+fun Fragment.requestMicrophonePermission(callback: (Boolean) -> Unit) {
+    requireContext().requestMicrophonePermission(Permissions.with(this), callback)
+}
+
+fun Activity.requestMicrophonePermission(callback: (Boolean) -> Unit) {
+    requestMicrophonePermission(Permissions.with(this), callback)
+}
+
+fun Context.requestMicrophonePermission(
+    permissions: Permissions.PermissionsBuilder,
+    callback: (Boolean) -> Unit
+) {
+    permissions
+        .request(Manifest.permission.RECORD_AUDIO)
+        .onAllGranted {
+            setBooleanPreference(
+                this,
+                TextSecurePreferences.CALL_NOTIFICATIONS_ENABLED,
+                true
+            )
+            callback(true)
+        }
+        .onAnyDenied { callback(false) }
+        .execute()
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/CallToggleListener.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/CallToggleListener.kt
@@ -9,6 +9,7 @@ import network.loki.messenger.R
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsession.utilities.TextSecurePreferences.Companion.setBooleanPreference
 import org.thoughtcrime.securesms.permissions.Permissions
+import org.thoughtcrime.securesms.permissions.requestMicrophonePermission
 import org.thoughtcrime.securesms.showSessionDialog
 
 internal class CallToggleListener(
@@ -29,30 +30,4 @@ internal class CallToggleListener(
 
         return false
     }
-}
-
-fun Fragment.requestMicrophonePermission(callback: (Boolean) -> Unit) {
-    requireContext().requestMicrophonePermission(Permissions.with(this), callback)
-}
-
-fun Activity.requestMicrophonePermission(callback: (Boolean) -> Unit) {
-    requestMicrophonePermission(Permissions.with(this), callback)
-}
-
-fun Context.requestMicrophonePermission(
-    permissions: Permissions.PermissionsBuilder,
-    callback: (Boolean) -> Unit
-) {
-    permissions
-        .request(Manifest.permission.RECORD_AUDIO)
-        .onAllGranted {
-            setBooleanPreference(
-                this,
-                TextSecurePreferences.CALL_NOTIFICATIONS_ENABLED,
-                true
-            )
-            callback(true)
-        }
-        .onAnyDenied { callback(false) }
-        .execute()
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/PrivacySettingsPreferenceFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/PrivacySettingsPreferenceFragment.kt
@@ -70,8 +70,7 @@ class PrivacySettingsPreferenceFragment : ListSummaryPreferenceFragment() {
     }
 
     private fun setCall(isEnabled: Boolean) {
-        (findPreference<Preference>(TextSecurePreferences.CALL_NOTIFICATIONS_ENABLED) as SwitchPreferenceCompat?)!!.isChecked =
-            isEnabled
+        findPreference<SwitchPreferenceCompat>(TextSecurePreferences.CALL_NOTIFICATIONS_ENABLED)!!.isChecked = isEnabled
         if (isEnabled && !areNotificationsEnabled(requireActivity())) {
             // show a dialog saying that calls won't work properly if you don't have notifications on at a system level
             showSessionDialog {


### PR DESCRIPTION
Permission can be revoked in system settings or when app is relaunched if one-time permission is granted.

This PR checks the preference is set, and also checks that the permission is set, before following through to making the call.