### PR TITLE
[SES-1889] Fix IndexOutOfBounds in MediaPreview

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -219,13 +219,6 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     Permissions.onRequestPermissionsResult(this, requestCode, permissions, grantResults);
   }
 
-  @TargetApi(VERSION_CODES.JELLY_BEAN)
-  private void setFullscreenIfPossible() {
-    if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN) {
-      getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_FULLSCREEN);
-    }
-  }
-
   @Override
   public void onModified(Recipient recipient) {
     Util.runOnMain(this::updateActionBar);
@@ -760,8 +753,8 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     }
 
     private int getCursorPosition(int position) {
-      if (leftIsRecent) return position;
-      else              return cursor.getCount() - 1 - position;
+        int unclamped = leftIsRecent ? position : cursor.getCount() - 1 - position;
+        return Math.max(Math.min(unclamped, cursor.getCount() - 1), 0);
     }
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -287,9 +287,6 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     mediaPager = findViewById(R.id.media_pager);
     mediaPager.setOffscreenPageLimit(1);
 
-    viewPagerListener = new ViewPagerListener();
-    mediaPager.addOnPageChangeListener(viewPagerListener);
-
     albumRail        = findViewById(R.id.media_preview_album_rail);
     albumRailAdapter = new MediaRailAdapter(GlideApp.with(this), this, false);
 
@@ -526,12 +523,17 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
   public void onLoadFinished(@NonNull Loader<Pair<Cursor, Integer>> loader, @Nullable Pair<Cursor, Integer> data) {
     if (data == null) return;
 
+    mediaPager.removeOnPageChangeListener(viewPagerListener);
+
     adapter = new CursorPagerAdapter(this, GlideApp.with(this), getWindow(), data.first, data.second, leftIsRecent);
     mediaPager.setAdapter(adapter);
 
     viewModel.setCursor(this, data.first, leftIsRecent);
 
     int item = restartItem >= 0  && restartItem < adapter.getCount() ? restartItem : Math.max(Math.min(data.second, adapter.getCount() - 1), 0);
+
+    viewPagerListener = new ViewPagerListener();
+    mediaPager.addOnPageChangeListener(viewPagerListener);
 
     try {
       mediaPager.setCurrentItem(item);

--- a/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -565,8 +565,12 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     public void onPageUnselected(int position) {
       if (adapter == null) return;
 
-      MediaItem item = adapter.getMediaItemFor(position);
-      if (item.recipient != null) item.recipient.removeListener(MediaPreviewActivity.this);
+      try {
+        MediaItem item = adapter.getMediaItemFor(position);
+        if (item.recipient != null) item.recipient.removeListener(MediaPreviewActivity.this);
+      } catch (CursorIndexOutOfBoundsException e) {
+        throw new RuntimeException("position = " + position + " leftIsRecent = " + leftIsRecent, e);
+      }
 
       adapter.pause(position);
     }


### PR DESCRIPTION
The issue is a crash that occurs onResume we load the cursor again and then set the pager position and that triggers viewPagerListener, but the listener is reused and holds an index which may or may not be valid. As range checks only check index is positive, we might have an index that exceeds the bounds, and if `leftIsRecent` is set then its reversed. This [commit](https://github.com/oxen-io/session-android/pull/1481/commits/cee06bf7ee3a31ed631413ef815befaa81d3aec2) fixes the issue and adds some additional info if we do throw.

It'd be good to rewrite this class in the near future

Th clamping in `onLoadFinished` also improves an issue when the Activity is started wiyh an inalid index causing the pager to not be populated at all when the activity is opened