### PR TITLE
Remove fast mode options from website build variant

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -166,7 +166,7 @@ android {
             dimension "distribution"
             ext.websiteUpdateUrl = "https://github.com/oxen-io/session-android/releases"
             buildConfigField "boolean", "PLAY_STORE_DISABLED", "true"
-            buildConfigField "org.session.libsession.utilities.Device", "DEVICE", "org.session.libsession.utilities.Device.ANDROID"
+            buildConfigField "org.session.libsession.utilities.Device", "DEVICE", "org.session.libsession.utilities.Device.FDROID"
             buildConfigField "String", "NOPLAY_UPDATE_URL", "\"$ext.websiteUpdateUrl\""
             buildConfigField 'String', 'PUSH_KEY_SUFFIX', '\"\"'
         }

--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -76,7 +76,6 @@ import org.thoughtcrime.securesms.notifications.BackgroundPollWorker;
 import org.thoughtcrime.securesms.notifications.DefaultMessageNotifier;
 import org.thoughtcrime.securesms.notifications.NotificationChannels;
 import org.thoughtcrime.securesms.notifications.OptimizedMessageNotifier;
-import org.thoughtcrime.securesms.notifications.PushRegistry;
 import org.thoughtcrime.securesms.providers.BlobProvider;
 import org.thoughtcrime.securesms.service.ExpiringMessageManager;
 import org.thoughtcrime.securesms.service.KeyCachingService;
@@ -147,7 +146,6 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
     @Inject Device device;
     @Inject MessageDataProvider messageDataProvider;
     @Inject TextSecurePreferences textSecurePreferences;
-    @Inject PushRegistry pushRegistry;
     @Inject ConfigFactory configFactory;
     CallMessageProcessor callMessageProcessor;
     MessagingModuleConfiguration messagingModuleConfiguration;

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.home
 
 import android.Manifest
+import android.app.Activity
 import android.app.NotificationManager
 import android.content.BroadcastReceiver
 import android.content.ClipData
@@ -72,6 +73,7 @@ import org.thoughtcrime.securesms.notifications.PushRegistry
 import org.thoughtcrime.securesms.onboarding.SeedActivity
 import org.thoughtcrime.securesms.onboarding.SeedReminderViewDelegate
 import org.thoughtcrime.securesms.permissions.Permissions
+import org.thoughtcrime.securesms.permissions.RationaleDialog.show
 import org.thoughtcrime.securesms.preferences.SettingsActivity
 import org.thoughtcrime.securesms.showMuteDialog
 import org.thoughtcrime.securesms.showSessionDialog
@@ -699,4 +701,14 @@ class HomeActivity : PassphraseRequiredActionBarActivity(),
     }
 
     // endregion
+}
+
+fun Activity.showHomeActivity() {
+    val application = ApplicationContext.getInstance(this)
+    application.startPollingIfNeeded()
+
+    val intent = Intent(this, HomeActivity::class.java)
+    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+    intent.putExtra(HomeActivity.FROM_ONBOARDING, true)
+    show(intent)
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/onboarding/DisplayNameActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/onboarding/DisplayNameActivity.kt
@@ -7,16 +7,25 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.TextView.OnEditorActionListener
 import android.widget.Toast
+import dagger.hilt.android.AndroidEntryPoint
 import network.loki.messenger.R
 import network.loki.messenger.databinding.ActivityDisplayNameBinding
+import org.session.libsession.utilities.Device
 import org.session.libsession.utilities.SSKEnvironment.ProfileManagerProtocol
 import org.thoughtcrime.securesms.BaseActionBarActivity
 import org.thoughtcrime.securesms.util.push
 import org.thoughtcrime.securesms.util.setUpActionBarSessionLogo
 import org.session.libsession.utilities.TextSecurePreferences
+import org.thoughtcrime.securesms.home.HomeActivity
+import org.thoughtcrime.securesms.home.showHomeActivity
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class DisplayNameActivity : BaseActionBarActivity() {
     private lateinit var binding: ActivityDisplayNameBinding
+
+    @Inject
+    lateinit var device: Device
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -51,7 +60,14 @@ class DisplayNameActivity : BaseActionBarActivity() {
         val inputMethodManager = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
         inputMethodManager.hideSoftInputFromWindow(binding.displayNameEditText.windowToken, 0)
         TextSecurePreferences.setProfileName(this, displayName)
-        val intent = Intent(this, PNModeActivity::class.java)
-        push(intent)
+        if (device.pushAvailable) {
+            val intent = Intent(
+                this,
+                PNModeActivity::class.java
+            )
+            push(intent)
+        } else {
+            showHomeActivity()
+        }
     }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/onboarding/LandingActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/onboarding/LandingActivity.kt
@@ -15,6 +15,8 @@ class LandingActivity : BaseActionBarActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        TextSecurePreferences.setHasSeenWelcomeScreen(this, true)
+
         // We always hit this LandingActivity on launch - but if there is a previous instance of
         // Session then close this activity to resume the last activity from the previous instance.
         if (!isTaskRoot) { finish(); return }

--- a/app/src/main/java/org/thoughtcrime/securesms/onboarding/LinkDeviceActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/onboarding/LinkDeviceActivity.kt
@@ -24,6 +24,7 @@ import network.loki.messenger.R
 import network.loki.messenger.databinding.ActivityLinkDeviceBinding
 import network.loki.messenger.databinding.FragmentRecoveryPhraseBinding
 import org.session.libsession.snode.SnodeModule
+import org.session.libsession.utilities.Device
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.crypto.MnemonicCodec
 import org.session.libsignal.database.LokiAPIDatabaseProtocol
@@ -36,6 +37,8 @@ import org.thoughtcrime.securesms.BaseActionBarActivity
 import org.thoughtcrime.securesms.crypto.KeyPairUtilities
 import org.thoughtcrime.securesms.crypto.MnemonicUtilities
 import org.thoughtcrime.securesms.dependencies.ConfigFactory
+import org.thoughtcrime.securesms.home.HomeActivity
+import org.thoughtcrime.securesms.home.showHomeActivity
 import org.thoughtcrime.securesms.util.ScanQRCodeWrapperFragment
 import org.thoughtcrime.securesms.util.ScanQRCodeWrapperFragmentDelegate
 import org.thoughtcrime.securesms.util.push
@@ -47,6 +50,8 @@ class LinkDeviceActivity : BaseActionBarActivity(), ScanQRCodeWrapperFragmentDel
 
     @Inject
     lateinit var configFactory: ConfigFactory
+    @Inject
+    lateinit var device: Device
 
     private lateinit var binding: ActivityLinkDeviceBinding
     internal val database: LokiAPIDatabaseProtocol
@@ -156,7 +161,14 @@ class LinkDeviceActivity : BaseActionBarActivity(), ScanQRCodeWrapperFragmentDel
         restoreJob?.cancel()
         binding.loader.isVisible = false
         TextSecurePreferences.setLastConfigurationSyncTime(this, System.currentTimeMillis())
-        val intent = Intent(this@LinkDeviceActivity, if (skipped) DisplayNameActivity::class.java else PNModeActivity::class.java)
+        val intent = Intent(
+            this@LinkDeviceActivity,
+            when {
+                skipped -> DisplayNameActivity::class.java
+                device.pushAvailable -> PNModeActivity::class.java
+                else -> { showHomeActivity(); return }
+            }
+        )
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         push(intent)
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/onboarding/PNModeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/onboarding/PNModeActivity.kt
@@ -15,11 +15,13 @@ import androidx.annotation.DrawableRes
 import dagger.hilt.android.AndroidEntryPoint
 import network.loki.messenger.R
 import network.loki.messenger.databinding.ActivityPnModeBinding
+import org.session.libsession.utilities.Device
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsession.utilities.ThemeUtil
 import org.thoughtcrime.securesms.ApplicationContext
 import org.thoughtcrime.securesms.BaseActionBarActivity
 import org.thoughtcrime.securesms.home.HomeActivity
+import org.thoughtcrime.securesms.home.showHomeActivity
 import org.thoughtcrime.securesms.notifications.PushManager
 import org.thoughtcrime.securesms.notifications.PushRegistry
 import org.thoughtcrime.securesms.showSessionDialog
@@ -166,14 +168,9 @@ class PNModeActivity : BaseActionBarActivity() {
             return
         }
 
-        TextSecurePreferences.setPushEnabled(this, (selectedOptionView == binding.fcmOptionView))
-        val application = ApplicationContext.getInstance(this)
-        application.startPollingIfNeeded()
+        TextSecurePreferences.setPushEnabled(this, selectedOptionView == binding.fcmOptionView)
         pushRegistry.refresh(true)
-        val intent = Intent(this, HomeActivity::class.java)
-        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-        intent.putExtra(HomeActivity.FROM_ONBOARDING, true)
-        show(intent)
+        showHomeActivity()
     }
     // endregion
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/NotificationsPreferenceFragment.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import network.loki.messenger.R
+import org.session.libsession.utilities.Device
 import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsession.utilities.TextSecurePreferences.Companion.isNotificationsEnabled
 import org.thoughtcrime.securesms.ApplicationContext
@@ -32,6 +33,8 @@ class NotificationsPreferenceFragment : ListSummaryPreferenceFragment() {
     lateinit var pushRegistry: PushRegistry
     @Inject
     lateinit var prefs: TextSecurePreferences
+    @Inject
+    lateinit var device: Device
 
     override fun onCreate(paramBundle: Bundle?) {
         super.onCreate(paramBundle)
@@ -39,6 +42,7 @@ class NotificationsPreferenceFragment : ListSummaryPreferenceFragment() {
         // Set up FCM toggle
         val fcmKey = "pref_key_use_fcm"
         val fcmPreference: SwitchPreferenceCompat = findPreference(fcmKey)!!
+        fcmPreference.isVisible = device.pushAvailable
         fcmPreference.isChecked = prefs.isPushEnabled()
         fcmPreference.setOnPreferenceChangeListener { _: Preference, newValue: Any ->
                 prefs.setPushEnabled(newValue as Boolean)

--- a/app/src/main/java/org/thoughtcrime/securesms/util/ActivityUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/ActivityUtilities.kt
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.util
 
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.view.View
@@ -38,10 +39,10 @@ fun BaseActionBarActivity.setUpActionBarSessionLogo(hideBackButton: Boolean = fa
     }
 }
 
-val AppCompatActivity.defaultSessionRequestCode: Int
+val Activity.defaultSessionRequestCode: Int
     get() = 42
 
-fun AppCompatActivity.push(intent: Intent, isForResult: Boolean = false) {
+fun Activity.push(intent: Intent, isForResult: Boolean = false) {
     if (isForResult) {
         startActivityForResult(intent, defaultSessionRequestCode)
     } else {
@@ -50,7 +51,7 @@ fun AppCompatActivity.push(intent: Intent, isForResult: Boolean = false) {
     overridePendingTransition(R.anim.slide_from_right, R.anim.fade_scale_out)
 }
 
-fun AppCompatActivity.show(intent: Intent, isForResult: Boolean = false) {
+fun Activity.show(intent: Intent, isForResult: Boolean = false) {
     if (isForResult) {
         startActivityForResult(intent, defaultSessionRequestCode)
     } else {

--- a/libsession/src/main/java/org/session/libsession/utilities/Device.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/Device.kt
@@ -1,6 +1,7 @@
 package org.session.libsession.utilities
 
-enum class Device(val value: String, val service: String = value) {
+enum class Device(val value: String, val service: String = value, val pushAvailable: Boolean = true) {
     ANDROID("android", "firebase"),
+    FDROID("fdroid", pushAvailable = false),
     HUAWEI("huawei");
 }


### PR DESCRIPTION
It seems our `website` build variant already avoids cloud messaging.

This PR skips the activity for choosing to use it or not, and the preference that does the same thing. This option would have no effect anyway.

This is a good step towards a play-services-free build on Fdroid, as these screens would be concerning to privacy-centric users, and misinformation to others who expected that they would benefit from fast mode.

https://github.com/oxen-io/session-android/issues/1427