### PR TITLE
SES1901- Last sent msg ANR fix

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -299,11 +299,11 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
 
     private val adapter by lazy {
 
-        // To prevent repeated attachment download jobs being spawned we'll keep a set of what
-        // attachmentId / mmsId pairs we've already attempted to download and only spawn the job
-        // if we haven't already done so. Without this then when the retry limit for a failed job
-        // hits another job is immediately spawned (endlessly).
-        var alreadyAttemptedAttachmentDownloadPairs = mutableSetOf<Pair<Long, Long>>()
+        // To prevent repeated attachment download jobs being spawned we'll keep track of the
+        // attachment Ids we've attempted to download, and only spawn job if we haven't already
+        // tried. Without this then when the retry limit for a failed job hits another job is
+        // immediately spawned (endlessly).
+        val alreadyAttemptedAttachmentDownloads = mutableSetOf<Long>()
 
         val cursor = mmsSmsDb.getConversation(viewModel.threadId, reverseMessageList)
         val adapter = ConversationAdapter(
@@ -332,12 +332,9 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
                 }
             },
             onAttachmentNeedsDownload = { attachmentId, mmsId ->
-                // Keep track of this specific attachment so we don't download it again
-                val pair = Pair(attachmentId, mmsId)
-                if (!alreadyAttemptedAttachmentDownloadPairs.contains(pair)) {
-                    alreadyAttemptedAttachmentDownloadPairs.add(pair)
 
-                    // Start download (on IO thread)
+                alreadyAttemptedAttachmentDownloads.takeUnless { attachmentId in alreadyAttemptedAttachmentDownloads }.let {
+                    alreadyAttemptedAttachmentDownloads += attachmentId
                     lifecycleScope.launch(Dispatchers.IO) {
                         JobQueue.shared.add(AttachmentDownloadJob(attachmentId, mmsId))
                     }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -372,6 +372,7 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
     private var currentLastVisibleRecyclerViewIndex:  Int = RecyclerView.NO_POSITION
     private var recyclerScrollState: Int = RecyclerView.SCROLL_STATE_IDLE
 
+
     // region Settings
     companion object {
         // Extras
@@ -387,6 +388,7 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
         const val PICK_FROM_LIBRARY = 12
         const val INVITE_CONTACTS = 124
 
+        var lastSentMessageId = -1L;
     }
     // endregion
 
@@ -513,6 +515,9 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
         viewModel.run {
             binding?.toolbarContent?.update(recipient ?: return, openGroup, expirationConfiguration)
         }
+
+        // Update our last sent message Id on startup / resume (resume is called after onCreate)
+        lastSentMessageId = mmsSmsDb.getLastOutgoingMessage(viewModel.threadId)
     }
 
     override fun onPause() {
@@ -2221,6 +2226,11 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
                 // to the bottom of long messages as required by Jira SES-789 / GitHub 1364).
                 recyclerView.scrollToPosition(adapter.itemCount)
             }
+
+            // Update our cached last sent message to ensure we have accurate details.
+            // Note: This `onChanged` method is not triggered when scrolling so should minimally
+            // affect performance.
+            lastSentMessageId = mmsSmsDb.getLastOutgoingMessage(viewModel.threadId)
         }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationAdapter.kt
@@ -60,8 +60,6 @@ class ConversationAdapter(
     private val contactLoadedCache = SparseBooleanArray(100)
     private val lastSeen = AtomicLong(originalLastSeen)
 
-    //private var lastSentMessageId: Long = -1L
-
     init {
         lifecycleCoroutineScope.launch(IO) {
             while (isActive) {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationAdapter.kt
@@ -59,7 +59,8 @@ class ConversationAdapter(
     private val contactCache = SparseArray<Contact>(100)
     private val contactLoadedCache = SparseBooleanArray(100)
     private val lastSeen = AtomicLong(originalLastSeen)
-    private var lastSentMessageId: Long = -1L
+
+    //private var lastSentMessageId: Long = -1L
 
     init {
         lifecycleCoroutineScope.launch(IO) {
@@ -241,11 +242,6 @@ class ConversationAdapter(
         toDeselect.iterator().forEach { (pos, record) ->
             onDeselect(record, pos)
         }
-
-        // This value gets updated here ONLY when the cursor changes, and the value is then passed
-        // through to `VisibleMessageView.bind` each time we bind via `onBindItemViewHolder`, above.
-        // If there are no messages then lastSentMessageId is assigned the value -1L.
-        if (cursor != null) { lastSentMessageId = getLastSentMessageId(cursor) }
     }
 
     fun findLastSeenItemPosition(lastSeenTimestamp: Long): Int? {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationAdapter.kt
@@ -139,8 +139,7 @@ class ConversationAdapter(
                         senderId,
                         lastSeen.get(),
                         visibleMessageViewDelegate,
-                        onAttachmentNeedsDownload,
-                        lastSentMessageId
+                        onAttachmentNeedsDownload
                 )
 
                 if (!message.isDeleted) {
@@ -216,8 +215,7 @@ class ConversationAdapter(
         if (cursorHasContent) {
             val thisThreadId = cursor.getLong(4) // Column index 4 is "thread_id"
             if (thisThreadId != -1L) {
-                val thisUsersSessionId = TextSecurePreferences.getLocalNumber(context)
-                return messageDB.getLastSentMessageFromSender(thisThreadId, thisUsersSessionId)
+                return messageDB.getLastOutgoingMessage(thisThreadId)
             }
         }
         return -1L

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
@@ -302,7 +302,6 @@ class VisibleMessageView : LinearLayout {
 
         // --- If we got here then we know the message is outgoing ---
 
-        //val lastSentMessageId = mmsSmsDb.getLastOutgoingMessage(message.threadId)
         val lastSentMessageId = ConversationActivityV2.lastSentMessageId;
         val isLastSentMessage = lastSentMessageId == message.id
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
@@ -134,8 +134,7 @@ class VisibleMessageView : LinearLayout {
         senderSessionID: String,
         lastSeen: Long,
         delegate: VisibleMessageViewDelegate? = null,
-        onAttachmentNeedsDownload: (Long, Long) -> Unit,
-        lastSentMessageId: Long
+        onAttachmentNeedsDownload: (Long, Long) -> Unit
     ) {
         replyDisabled = message.isOpenGroupInvitation
         val threadID = message.threadId
@@ -303,8 +302,7 @@ class VisibleMessageView : LinearLayout {
 
         // --- If we got here then we know the message is outgoing ---
 
-        val thisUsersSessionId = TextSecurePreferences.getLocalNumber(context)
-        val lastSentMessageId = mmsSmsDb.getLastSentMessageFromSender(message.threadId, thisUsersSessionId)
+        val lastSentMessageId = mmsSmsDb.getLastOutgoingMessage(message.threadId)
         val isLastSentMessage = lastSentMessageId == message.id
 
         // ----- Case ii.) Message is outgoing but NOT scheduled to disappear -----

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
@@ -302,7 +302,8 @@ class VisibleMessageView : LinearLayout {
 
         // --- If we got here then we know the message is outgoing ---
 
-        val lastSentMessageId = mmsSmsDb.getLastOutgoingMessage(message.threadId)
+        //val lastSentMessageId = mmsSmsDb.getLastOutgoingMessage(message.threadId)
+        val lastSentMessageId = ConversationActivityV2.lastSentMessageId;
         val isLastSentMessage = lastSentMessageId == message.id
 
         // ----- Case ii.) Message is outgoing but NOT scheduled to disappear -----

--- a/app/src/main/java/org/thoughtcrime/securesms/database/MmsSmsColumns.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MmsSmsColumns.java
@@ -9,7 +9,11 @@ public interface MmsSmsColumns {
   public static final String THREAD_ID                = "thread_id";
   public static final String READ                     = "read";
   public static final String BODY                     = "body";
+
+  // This is the address of the message recipient, which may be a single user, a group, or a community!
+  // It is NOT the address of the sender of any given message!
   public static final String ADDRESS                  = "address";
+
   public static final String ADDRESS_DEVICE_ID        = "address_device_id";
   public static final String DELIVERY_RECEIPT_COUNT   = "delivery_receipt_count";
   public static final String READ_RECEIPT_COUNT       = "read_receipt_count";

--- a/app/src/main/java/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
@@ -306,7 +306,7 @@ public class MmsSmsDatabase extends Database {
         MessageRecord messageRecord;
         while ((messageRecord = reader.getNext()) != null) {
           // Note: We rely on the message order to get us the most recent outgoing message - so we
-          // take the first outgoing message we find.
+          // take the first outgoing message we find as the last outgoing message.
           if (messageRecord.isOutgoing()) return messageRecord.id;
         }
       }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
@@ -299,8 +299,7 @@ public class MmsSmsDatabase extends Database {
     String order = MmsSmsColumns.NORMALIZED_DATE_SENT + " DESC";
     String selection = MmsSmsColumns.THREAD_ID + " = " + threadId;
 
-    // Try everything with resources so that they auto-close on end of scope.
-    // Note: Do NOT call cursor.moveToFirst() once we have it, for reasons unknown to me it breaks the functionality. -AL
+    // Try everything with resources so that they auto-close on end of scope
     try (Cursor cursor = queryTables(PROJECTION, selection, order, null)) {
       try (MmsSmsDatabase.Reader reader = readerFor(cursor)) {
         MessageRecord messageRecord;

--- a/app/src/main/java/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
@@ -305,7 +305,12 @@ public class MmsSmsDatabase extends Database {
     }
 
     String order = MmsSmsColumns.NORMALIZED_DATE_SENT + " DESC";
-    String selection = MmsSmsColumns.THREAD_ID + " = " + threadId;
+
+    // As the MmsSmsDatabase.ADDRESS column never contains the sender address we have to get creative to filter down all the
+    // messages that have been sent without interrogating each MessageRecord returned by the cursor. One way to do this is
+    // via the fact that the `ADDRESS_DEVICE_ID` is always null for incoming messages, but always has a value (such as 1) for
+    // outgoing messages - so we'll filter our query for only records with non-null ADDRESS_DEVICE_IDs in the current thread.
+    String selection = MmsSmsColumns.THREAD_ID + " = " + threadId + " AND " + MmsSmsColumns.ADDRESS_DEVICE_ID + " IS NOT NULL";
 
     // Try everything with resources so that they auto-close on end of scope
     try (Cursor cursor = queryTables(PROJECTION, selection, order, null)) {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have tested my contribution on these devices:
 * Virtual Pixel 3a, Android 9 / API 28
 * Virtual Pixel 3a, Android 14 / API 34
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
App Not Responding reports generated due to large numbers of last sent message look-ups in combination with re-spawning attachment download jobs.

This PR provides a more streamlined SQLite query for the last sent message lookup which results in less time / work spent stepping through messages to determine if they are outgoing or not, as well as attachment jobs being prevented from re-running (technically another job is created each time - but it's attempting to download the same attachment that failed to download when the first job tried it).