### PR TITLE
Prevent reloading sodium

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/crypto/KeyPairUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/crypto/KeyPairUtilities.kt
@@ -1,10 +1,9 @@
 package org.thoughtcrime.securesms.crypto
 
 import android.content.Context
-import com.goterl.lazysodium.LazySodiumAndroid
-import com.goterl.lazysodium.SodiumAndroid
 import com.goterl.lazysodium.utils.Key
 import com.goterl.lazysodium.utils.KeyPair
+import org.session.libsession.messaging.utilities.SodiumUtilities.sodium
 import org.session.libsignal.crypto.ecc.DjbECPrivateKey
 import org.session.libsignal.crypto.ecc.DjbECPublicKey
 import org.session.libsignal.crypto.ecc.ECKeyPair
@@ -12,8 +11,6 @@ import org.session.libsignal.utilities.Base64
 import org.session.libsignal.utilities.Hex
 
 object KeyPairUtilities {
-
-    private val sodium by lazy { LazySodiumAndroid(SodiumAndroid()) }
 
     fun generate(): KeyPairGenerationResult {
         val seed = sodium.randomBytesBuf(16)

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/PushReceiver.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/PushReceiver.kt
@@ -17,6 +17,7 @@ import org.session.libsession.messaging.jobs.MessageReceiveParameters
 import org.session.libsession.messaging.sending_receiving.notifications.PushNotificationMetadata
 import org.session.libsession.messaging.utilities.MessageWrapper
 import org.session.libsession.messaging.utilities.SodiumUtilities
+import org.session.libsession.messaging.utilities.SodiumUtilities.sodium
 import org.session.libsession.utilities.bencode.Bencode
 import org.session.libsession.utilities.bencode.BencodeList
 import org.session.libsession.utilities.bencode.BencodeString
@@ -28,7 +29,6 @@ import javax.inject.Inject
 private const val TAG = "PushHandler"
 
 class PushReceiver @Inject constructor(@ApplicationContext val context: Context) {
-    private val sodium = LazySodiumAndroid(SodiumAndroid())
     private val json = Json { ignoreUnknownKeys = true }
 
     fun onPush(dataMap: Map<String, String>?) {

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/PushRegistryV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/PushRegistryV2.kt
@@ -18,6 +18,8 @@ import org.session.libsession.messaging.sending_receiving.notifications.Subscrip
 import org.session.libsession.messaging.sending_receiving.notifications.SubscriptionResponse
 import org.session.libsession.messaging.sending_receiving.notifications.UnsubscribeResponse
 import org.session.libsession.messaging.sending_receiving.notifications.UnsubscriptionRequest
+import org.session.libsession.messaging.utilities.SodiumUtilities
+import org.session.libsession.messaging.utilities.SodiumUtilities.sodium
 import org.session.libsession.snode.OnionRequestAPI
 import org.session.libsession.snode.SnodeAPI
 import org.session.libsession.snode.Version
@@ -34,8 +36,6 @@ private const val maxRetryCount = 4
 
 @Singleton
 class PushRegistryV2 @Inject constructor(private val pushReceiver: PushReceiver) {
-    private val sodium = LazySodiumAndroid(SodiumAndroid())
-
     fun register(
         device: Device,
         token: String,

--- a/libsession/src/main/java/org/session/libsession/messaging/open_groups/OpenGroupApi.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/open_groups/OpenGroupApi.kt
@@ -21,6 +21,7 @@ import org.session.libsession.messaging.MessagingModuleConfiguration
 import org.session.libsession.messaging.sending_receiving.pollers.OpenGroupPoller.Companion.maxInactivityPeriod
 import org.session.libsession.messaging.utilities.SessionId
 import org.session.libsession.messaging.utilities.SodiumUtilities
+import org.session.libsession.messaging.utilities.SodiumUtilities.sodium
 import org.session.libsession.snode.OnionRequestAPI
 import org.session.libsession.snode.OnionResponse
 import org.session.libsession.snode.SnodeAPI
@@ -48,7 +49,6 @@ object OpenGroupApi {
     val defaultRooms = MutableSharedFlow<List<DefaultGroup>>(replay = 1)
     private val hasPerformedInitialPoll = mutableMapOf<String, Boolean>()
     private var hasUpdatedLastOpenDate = false
-    private val sodium by lazy { LazySodiumAndroid(SodiumAndroid()) }
     private val timeSinceLastOpen by lazy {
         val context = MessagingModuleConfiguration.shared.context
         val lastOpenDate = TextSecurePreferences.getLastOpenTimeDate(context)

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageDecrypter.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageDecrypter.kt
@@ -8,6 +8,7 @@ import org.session.libsession.messaging.MessagingModuleConfiguration
 import org.session.libsession.messaging.sending_receiving.MessageReceiver.Error
 import org.session.libsession.messaging.utilities.SessionId
 import org.session.libsession.messaging.utilities.SodiumUtilities
+import org.session.libsession.messaging.utilities.SodiumUtilities.sodium
 import org.session.libsignal.crypto.ecc.ECKeyPair
 import org.session.libsignal.utilities.Hex
 import org.session.libsignal.utilities.IdPrefix
@@ -16,8 +17,6 @@ import org.session.libsignal.utilities.hexEncodedPublicKey
 import org.session.libsignal.utilities.removingIdPrefixIfNeeded
 
 object MessageDecrypter {
-
-    private val sodium by lazy { LazySodiumAndroid(SodiumAndroid()) }
 
     /**
      * Decrypts `ciphertext` using the Session protocol and `x25519KeyPair`.

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageEncrypter.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageEncrypter.kt
@@ -7,14 +7,13 @@ import com.goterl.lazysodium.interfaces.Sign
 import org.session.libsession.messaging.MessagingModuleConfiguration
 import org.session.libsession.messaging.sending_receiving.MessageSender.Error
 import org.session.libsession.messaging.utilities.SodiumUtilities
+import org.session.libsession.messaging.utilities.SodiumUtilities.sodium
 import org.session.libsignal.utilities.Hex
 import org.session.libsignal.utilities.IdPrefix
 import org.session.libsignal.utilities.Log
 import org.session.libsignal.utilities.removingIdPrefixIfNeeded
 
 object MessageEncrypter {
-
-    private val sodium by lazy { LazySodiumAndroid(SodiumAndroid()) }
 
     /**
      * Encrypts `plaintext` using the Session protocol for `hexEncodedX25519PublicKey`.

--- a/libsession/src/main/java/org/session/libsession/messaging/utilities/SodiumUtilities.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/utilities/SodiumUtilities.kt
@@ -14,7 +14,7 @@ import org.whispersystems.curve25519.Curve25519
 import kotlin.experimental.xor
 
 object SodiumUtilities {
-    private val sodium by lazy { LazySodiumAndroid(SodiumAndroid()) }
+    val sodium by lazy { LazySodiumAndroid(SodiumAndroid()) }
     private val curve by lazy { Curve25519.getInstance(Curve25519.BEST) }
 
     private const val SCALAR_LENGTH: Int = 32 // crypto_core_ed25519_scalarbytes

--- a/libsession/src/main/java/org/session/libsession/snode/SnodeAPI.kt
+++ b/libsession/src/main/java/org/session/libsession/snode/SnodeAPI.kt
@@ -3,8 +3,6 @@
 package org.session.libsession.snode
 
 import android.os.Build
-import com.goterl.lazysodium.LazySodiumAndroid
-import com.goterl.lazysodium.SodiumAndroid
 import com.goterl.lazysodium.exceptions.SodiumException
 import com.goterl.lazysodium.interfaces.GenericHash
 import com.goterl.lazysodium.interfaces.PwHash
@@ -19,6 +17,7 @@ import nl.komponents.kovenant.functional.map
 import nl.komponents.kovenant.task
 import org.session.libsession.messaging.MessagingModuleConfiguration
 import org.session.libsession.messaging.utilities.MessageWrapper
+import org.session.libsession.messaging.utilities.SodiumUtilities.sodium
 import org.session.libsignal.crypto.getRandomElement
 import org.session.libsignal.database.LokiAPIDatabaseProtocol
 import org.session.libsignal.protos.SignalServiceProtos
@@ -41,7 +40,6 @@ import kotlin.collections.set
 import kotlin.properties.Delegates.observable
 
 object SnodeAPI {
-    private val sodium by lazy { LazySodiumAndroid(SodiumAndroid()) }
     internal val database: LokiAPIDatabaseProtocol
         get() = SnodeModule.shared.storage
     private val broadcaster: Broadcaster


### PR DESCRIPTION
This PR makes all usages of Sodium rely on the same instance so we don't reload the library.