### PR TITLE
[SES-1930] Catch HTTP exceptions from threads

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,8 +31,8 @@ configurations.all {
     exclude module: "commons-logging"
 }
 
-def canonicalVersionCode = 373
-def canonicalVersionName = "1.18.3"
+def canonicalVersionCode = 371
+def canonicalVersionName = "1.18.2"
 
 def postFixSize = 10
 def abiPostFix = ['armeabi-v7a' : 1,

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,8 +31,8 @@ configurations.all {
     exclude module: "commons-logging"
 }
 
-def canonicalVersionCode = 371
-def canonicalVersionName = "1.18.2"
+def canonicalVersionCode = 373
+def canonicalVersionName = "1.18.3"
 
 def postFixSize = 10
 def abiPostFix = ['armeabi-v7a' : 1,

--- a/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
+++ b/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
@@ -1,15 +1,11 @@
 package org.session.libsignal.utilities
 
 import android.os.Process
-import java.io.File
-import java.lang.Thread.getAllStackTraces
 import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
-import java.util.regex.Pattern
 
 object ThreadUtils {
 
@@ -25,13 +21,14 @@ object ThreadUtils {
     // very sharp tool that doesn't include any backpressure mechanism - and a sudden peak in load
     // can bring the system down with an OutOfMemory error. We can achieve a similar effect but with
     // better control by creating a ThreadPoolExecutor manually."
-    private val corePoolSize      = getCPUCoreCount()  // Minimum number of threads in the pool is our CPU core count
-    private val maxPoolSize       = corePoolSize * 4   // Allow a maximum pool size of up to 4 threads per core
-    private val keepAliveTimeSecs = 100L               // How long to keep idle threads in the pool before they are terminated
+
+    private val corePoolSize      = Runtime.getRuntime().availableProcessors() // Default thread pool size is our CPU core count
+    private val maxPoolSize       = corePoolSize * 4                           // Allow a maximum pool size of up to 4 threads per core
+    private val keepAliveTimeSecs = 100L                                       // How long to keep idle threads in the pool before they are terminated
     private val workQueue         = SynchronousQueue<Runnable>()
     val executorPool: ExecutorService = ThreadPoolExecutor(corePoolSize, maxPoolSize, keepAliveTimeSecs, TimeUnit.SECONDS, workQueue)
 
-    // Note: To see how many threads are running in our app at any given time we can use the following:
+    // Note: To see how many threads are running in our app at any given time we can use:
     // val threadCount = getAllStackTraces().size
 
     @JvmStatic
@@ -61,16 +58,5 @@ object ThreadUtils {
         val executor = ThreadPoolExecutor(1, 1, 60, TimeUnit.SECONDS, LinkedBlockingQueue())
         executor.allowCoreThreadTimeOut(true)
         return executor
-    }
-
-    private fun getCPUCoreCount(): Int {
-        val pattern = Pattern.compile("cpu[0-9]+")
-        return Math.max(
-            File("/sys/devices/system/cpu/")
-                .walk()
-                .maxDepth(1)
-                .count { pattern.matcher(it.name).matches() },
-            Runtime.getRuntime().availableProcessors()
-        )
     }
 }

--- a/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
+++ b/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
@@ -2,7 +2,9 @@ package org.session.libsignal.utilities
 
 import android.os.Process
 import java.io.File
+import java.lang.Thread.getAllStackTraces
 import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.ThreadPoolExecutor
@@ -13,27 +15,44 @@ object ThreadUtils {
 
     const val PRIORITY_IMPORTANT_BACKGROUND_THREAD = Process.THREAD_PRIORITY_DEFAULT + Process.THREAD_PRIORITY_LESS_FAVORABLE
 
-    // From: https://www.baeldung.com/kotlin/create-thread-pool
-    // "A cached thread pool will utilize resources according to the requirements of submitted
-    // tasks. It will try to reuse existing threads for submitted tasks but will create up to
-    // Integer.MAX_VALUE threads if needed. These threads will live for 60 seconds before
-    // terminating. As such, it presents a very sharp tool that doesn’t include any backpressure
-    // mechanism - and a sudden peak in load can bring the system down with an OutOfMemoryError.
-    // We can achieve a similar effect but with better control by creating a ThreadPoolExecutor
-    // manually."
-    private val corePoolSize      = getCPUCoreCount()  // Get the CPU core count
-    private val maximumPoolSize   = corePoolSize * 4   // Allow up to 4 threads per core
-    private val keepAliveTimeSecs = 100L               // Which may execute for up to 100 seconds
+    // Paraphrased from: https://www.baeldung.com/kotlin/create-thread-pool
+    // "A cached thread pool such as one created via:
+    // `val executorPool: ExecutorService = Executors.newCachedThreadPool()`
+    // will utilize resources according to the requirements of submitted tasks. It will try to reuse
+    // existing threads for submitted tasks but will create as many threads as it needs if new tasks
+    // keep pouring in (with a memory usage of at least 1MB per created thread). These threads will
+    // live for up to 60 seconds of idle time before terminating by default. As such, it presents a
+    // very sharp tool that doesn't include any backpressure mechanism - and a sudden peak in load
+    // can bring the system down with an OutOfMemory error. We can achieve a similar effect but with
+    // better control by creating a ThreadPoolExecutor manually."
+    private val corePoolSize      = getCPUCoreCount()  // Minimum number of threads in the pool is our CPU core count
+    private val maxPoolSize       = corePoolSize * 4   // Allow a maximum pool size of up to 4 threads per core
+    private val keepAliveTimeSecs = 100L               // How long to keep idle threads in the pool before they are terminated
     private val workQueue         = SynchronousQueue<Runnable>()
-    val executorPool: ExecutorService = ThreadPoolExecutor(corePoolSize, maximumPoolSize, keepAliveTimeSecs, TimeUnit.SECONDS, workQueue)
+    val executorPool: ExecutorService = ThreadPoolExecutor(corePoolSize, maxPoolSize, keepAliveTimeSecs, TimeUnit.SECONDS, workQueue)
+
+    // Note: To see how many threads are running in our app at any given time we can use the following:
+    // val threadCount = getAllStackTraces().size
 
     @JvmStatic
     fun queue(target: Runnable) {
-        executorPool.execute(target)
+        executorPool.execute {
+            try {
+                target.run()
+            } catch (e: Exception) {
+                Log.e("ThreadUtils", "Error in thread: ${e.message}")
+            }
+        }
     }
 
     fun queue(target: () -> Unit) {
-        executorPool.execute(target)
+        executorPool.execute {
+            try {
+                target()
+            } catch (e: Exception) {
+                Log.e("ThreadUtils", "Error in thread: ${e.message}")
+            }
+        }
     }
 
     // Thread executor used by the audio recorder only

--- a/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
+++ b/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
@@ -11,11 +11,21 @@ object ThreadUtils {
 
     @JvmStatic
     fun queue(target: Runnable) {
-        executorPool.execute(target)
+        try {
+            executorPool.execute(target)
+        }
+        catch (e: Exception) {
+            Log.e("ThreadUtils", "Exception returned from queue job: ${e.message}")
+        }
     }
 
     fun queue(target: () -> Unit) {
-        executorPool.execute(target)
+        try {
+            executorPool.execute(target)
+        }
+        catch (e: Exception) {
+            Log.e("ThreadUtils", "Exception returned from queue job: ${e.message}")
+        }
     }
 
     @JvmStatic

--- a/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
+++ b/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
@@ -37,8 +37,7 @@ object ThreadUtils {
             try {
                 target.run()
             } catch (e: Exception) {
-                Log.e("ThreadUtils", "Error in thread: ${e.message}")
-                e.printStackTrace()
+                Log.e("ThreadUtils", e)
             }
         }
     }
@@ -48,8 +47,7 @@ object ThreadUtils {
             try {
                 target()
             } catch (e: Exception) {
-                Log.e("ThreadUtils", "Error in thread: ${e.message}")
-                e.printStackTrace()
+                Log.e("ThreadUtils", e)
             }
         }
     }

--- a/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
+++ b/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
@@ -38,6 +38,7 @@ object ThreadUtils {
                 target.run()
             } catch (e: Exception) {
                 Log.e("ThreadUtils", "Error in thread: ${e.message}")
+                e.printStackTrace()
             }
         }
     }
@@ -48,6 +49,7 @@ object ThreadUtils {
                 target()
             } catch (e: Exception) {
                 Log.e("ThreadUtils", "Error in thread: ${e.message}")
+                e.printStackTrace()
             }
         }
     }

--- a/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
+++ b/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
@@ -15,7 +15,7 @@ object ThreadUtils {
             executorPool.execute(target)
         }
         catch (e: Exception) {
-            Log.e("ThreadUtils", "Exception returned from queue job: ${e.message}")
+            Log.e("ThreadUtils", "Exception returned from queue job: ${e.message}") 
         }
     }
 

--- a/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
+++ b/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
@@ -9,6 +9,8 @@ import java.util.concurrent.TimeUnit
 
 object ThreadUtils {
 
+    const val TAG = "ThreadUtils"
+
     const val PRIORITY_IMPORTANT_BACKGROUND_THREAD = Process.THREAD_PRIORITY_DEFAULT + Process.THREAD_PRIORITY_LESS_FAVORABLE
 
     // Paraphrased from: https://www.baeldung.com/kotlin/create-thread-pool
@@ -37,7 +39,7 @@ object ThreadUtils {
             try {
                 target.run()
             } catch (e: Exception) {
-                Log.e("ThreadUtils", e)
+                Log.e(TAG, e)
             }
         }
     }
@@ -47,7 +49,7 @@ object ThreadUtils {
             try {
                 target()
             } catch (e: Exception) {
-                Log.e("ThreadUtils", e)
+                Log.e(TAG, e)
             }
         }
     }

--- a/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
+++ b/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
@@ -1,37 +1,57 @@
 package org.session.libsignal.utilities
 
 import android.os.Process
-import java.util.concurrent.*
+import java.io.File
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.SynchronousQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import java.util.regex.Pattern
 
 object ThreadUtils {
 
     const val PRIORITY_IMPORTANT_BACKGROUND_THREAD = Process.THREAD_PRIORITY_DEFAULT + Process.THREAD_PRIORITY_LESS_FAVORABLE
 
-    val executorPool: ExecutorService = Executors.newCachedThreadPool()
+    // From: https://www.baeldung.com/kotlin/create-thread-pool
+    // "A cached thread pool will utilize resources according to the requirements of submitted
+    // tasks. It will try to reuse existing threads for submitted tasks but will create up to
+    // Integer.MAX_VALUE threads if needed. These threads will live for 60 seconds before
+    // terminating. As such, it presents a very sharp tool that doesn’t include any backpressure
+    // mechanism - and a sudden peak in load can bring the system down with an OutOfMemoryError.
+    // We can achieve a similar effect but with better control by creating a ThreadPoolExecutor
+    // manually."
+    private val corePoolSize      = getCPUCoreCount()  // Get the CPU core count
+    private val maximumPoolSize   = corePoolSize * 4   // Allow up to 4 threads per core
+    private val keepAliveTimeSecs = 100L               // Which may execute for up to 100 seconds
+    private val workQueue         = SynchronousQueue<Runnable>()
+    val executorPool: ExecutorService = ThreadPoolExecutor(corePoolSize, maximumPoolSize, keepAliveTimeSecs, TimeUnit.SECONDS, workQueue)
 
     @JvmStatic
     fun queue(target: Runnable) {
-        try {
-            executorPool.execute(target)
-        }
-        catch (e: Exception) {
-            Log.e("ThreadUtils", "Exception returned from queue job: ${e.message}") 
-        }
+        executorPool.execute(target)
     }
 
     fun queue(target: () -> Unit) {
-        try {
-            executorPool.execute(target)
-        }
-        catch (e: Exception) {
-            Log.e("ThreadUtils", "Exception returned from queue job: ${e.message}")
-        }
+        executorPool.execute(target)
     }
 
+    // Thread executor used by the audio recorder only
     @JvmStatic
     fun newDynamicSingleThreadedExecutor(): ExecutorService {
         val executor = ThreadPoolExecutor(1, 1, 60, TimeUnit.SECONDS, LinkedBlockingQueue())
         executor.allowCoreThreadTimeOut(true)
         return executor
+    }
+
+    private fun getCPUCoreCount(): Int {
+        val pattern = Pattern.compile("cpu[0-9]+")
+        return Math.max(
+            File("/sys/devices/system/cpu/")
+                .walk()
+                .maxDepth(1)
+                .count { pattern.matcher(it.name).matches() },
+            Runtime.getRuntime().availableProcessors()
+        )
     }
 }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have tested my contribution on these devices:
 * Virtual Pixel 3a, Android 9 / API 28
 * Virtual Pixel 3a, Android 14 / API 34
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
Exceptions thrown from `HTTP.kt` have been causing crashes - specifically when the device is not connected to the network (`HTTPNoNetworkConnection`) or if an operation failed due to a timeout (`HTTPRequestFailedException`). This PR simply catches the exceptions and logs them in the `ThreadUtil.queue` functions to prevent a crash.