### PR TITLE
[SES-1931] - Fix debouncer crash

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/ConversationNotificationDebouncer.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/ConversationNotificationDebouncer.kt
@@ -5,9 +5,9 @@ import android.content.Context
 import org.session.libsession.utilities.Debouncer
 import org.thoughtcrime.securesms.ApplicationContext
 
-class ConversationNotificationDebouncer(private val context: Context) {
+class ConversationNotificationDebouncer(private val context: ApplicationContext) {
     private val threadIDs = mutableSetOf<Long>()
-    private val handler = (context.applicationContext as ApplicationContext).conversationListNotificationHandler
+    private val handler = context.conversationListNotificationHandler
     private val debouncer = Debouncer(handler, 100)
 
     companion object {
@@ -17,20 +17,28 @@ class ConversationNotificationDebouncer(private val context: Context) {
         @Synchronized
         fun get(context: Context): ConversationNotificationDebouncer {
             if (::shared.isInitialized) { return shared }
-            shared = ConversationNotificationDebouncer(context)
+            shared = ConversationNotificationDebouncer(context.applicationContext as ApplicationContext)
             return shared
         }
     }
 
     fun notify(threadID: Long) {
-        threadIDs.add(threadID)
+        synchronized(threadIDs) {
+            threadIDs.add(threadID)
+        }
+
         debouncer.publish { publish() }
     }
 
     private fun publish() {
-        for (threadID in threadIDs.toList()) {
+        val toNotify = synchronized(threadIDs) {
+            val copy = threadIDs.toList()
+            threadIDs.clear()
+            copy
+        }
+
+        for (threadID in toNotify) {
             context.contentResolver.notifyChange(DatabaseContentProviders.Conversation.getUriForThread(threadID), null)
         }
-        threadIDs.clear()
     }
 }


### PR DESCRIPTION
### Description
The `ConversationNotificationDebouncer` doesn't handle threaded code correctly, added sync block manually. 

This PR also makes sure no activity context is ever stored inside this singleton object.
