### PR TITLE
[SES-1935] Audio recording crash

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/audio/AudioRecorder.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/audio/AudioRecorder.java
@@ -45,7 +45,8 @@ public class AudioRecorder {
       Log.i(TAG, "Running startRecording() + " + Thread.currentThread().getId());
       try {
         if (audioCodec != null) {
-          throw new AssertionError("We can only record once at a time.");
+          Log.e(TAG, "We can only record once at a time.");
+          return;
         }
 
         ParcelFileDescriptor fds[] = ParcelFileDescriptor.createPipe();

--- a/app/src/main/java/org/thoughtcrime/securesms/audio/AudioRecorder.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/audio/AudioRecorder.java
@@ -45,7 +45,7 @@ public class AudioRecorder {
       Log.i(TAG, "Running startRecording() + " + Thread.currentThread().getId());
       try {
         if (audioCodec != null) {
-          Log.e(TAG, "We can only record once at a time.");
+          Log.e(TAG, "Trying to start recording while another recording is in progress, exiting...");
           return;
         }
 


### PR DESCRIPTION
### Description
I tried to find a way to trigger a double call to `startRecording` and failed to find any. Instead of hard crashing the app, I think it's ok to ignore the edge case here, by logging the invariant then return early.

So the worst thing it could happen is for some edgy case the recording can't be started.
