### PR TITLE
[SES-1948] Do not fetch quotes recursively

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/database/MmsDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MmsDatabase.kt
@@ -1147,13 +1147,9 @@ class MmsDatabase(context: Context, databaseHelper: SQLCipherOpenHelper) : Messa
         }
     }
 
-    fun readerFor(cursor: Cursor?): Reader {
-        return Reader(cursor)
-    }
+    fun readerFor(cursor: Cursor?, getQuote: Boolean = true) = Reader(cursor, getQuote)
 
-    fun readerFor(message: OutgoingMediaMessage?, threadId: Long): OutgoingMessageReader {
-        return OutgoingMessageReader(message, threadId)
-    }
+    fun readerFor(message: OutgoingMediaMessage?, threadId: Long) = OutgoingMessageReader(message, threadId)
 
     fun setQuoteMissing(messageId: Long): Int {
         val contentValues = ContentValues()
@@ -1217,7 +1213,7 @@ class MmsDatabase(context: Context, databaseHelper: SQLCipherOpenHelper) : Messa
 
     }
 
-    inner class Reader(private val cursor: Cursor?) : Closeable {
+    inner class Reader(private val cursor: Cursor?, private val getQuote: Boolean = true) : Closeable {
         val next: MessageRecord?
             get() = if (cursor == null || !cursor.moveToNext()) null else current
         val current: MessageRecord
@@ -1226,7 +1222,7 @@ class MmsDatabase(context: Context, databaseHelper: SQLCipherOpenHelper) : Messa
                 return if (mmsType == PduHeaders.MESSAGE_TYPE_NOTIFICATION_IND.toLong()) {
                     getNotificationMmsMessageRecord(cursor)
                 } else {
-                    getMediaMmsMessageRecord(cursor)
+                    getMediaMmsMessageRecord(cursor, getQuote)
                 }
             }
 
@@ -1253,20 +1249,10 @@ class MmsDatabase(context: Context, databaseHelper: SQLCipherOpenHelper) : Messa
                     DELIVERY_RECEIPT_COUNT
                 )
             )
-            var readReceiptCount = cursor.getInt(cursor.getColumnIndexOrThrow(READ_RECEIPT_COUNT))
-            val subscriptionId = cursor.getInt(cursor.getColumnIndexOrThrow(SUBSCRIPTION_ID))
+            val readReceiptCount = if (isReadReceiptsEnabled(context)) cursor.getInt(cursor.getColumnIndexOrThrow(READ_RECEIPT_COUNT)) else 0
             val hasMention = (cursor.getInt(cursor.getColumnIndexOrThrow(HAS_MENTION)) == 1)
-            if (!isReadReceiptsEnabled(context)) {
-                readReceiptCount = 0
-            }
-            var contentLocationBytes: ByteArray? = null
-            var transactionIdBytes: ByteArray? = null
-            if (!contentLocation.isNullOrEmpty()) contentLocationBytes = toIsoBytes(
-                contentLocation
-            )
-            if (!transactionId.isNullOrEmpty()) transactionIdBytes = toIsoBytes(
-                transactionId
-            )
+            val contentLocationBytes: ByteArray? = contentLocation?.takeUnless { it.isEmpty() }?.let(::toIsoBytes)
+            val transactionIdBytes: ByteArray? = transactionId?.takeUnless { it.isEmpty() }?.let(::toIsoBytes)
             val slideDeck = SlideDeck(context, MmsNotificationAttachment(status, messageSize))
             return NotificationMmsMessageRecord(
                 id, recipient, recipient,
@@ -1277,7 +1263,7 @@ class MmsDatabase(context: Context, databaseHelper: SQLCipherOpenHelper) : Messa
             )
         }
 
-        private fun getMediaMmsMessageRecord(cursor: Cursor): MediaMmsMessageRecord {
+        private fun getMediaMmsMessageRecord(cursor: Cursor, getQuote: Boolean): MediaMmsMessageRecord {
             val id = cursor.getLong(cursor.getColumnIndexOrThrow(ID))
             val dateSent = cursor.getLong(cursor.getColumnIndexOrThrow(NORMALIZED_DATE_SENT))
             val dateReceived = cursor.getLong(
@@ -1328,7 +1314,7 @@ class MmsDatabase(context: Context, databaseHelper: SQLCipherOpenHelper) : Messa
                     .filterNot { o: DatabaseAttachment? -> o in contactAttachments }
                     .filterNot { o: DatabaseAttachment? -> o in previewAttachments }
             )
-            val quote = getQuote(cursor)
+            val quote = if (getQuote) getQuote(cursor) else null
             val reactions = get(context).reactionDatabase().getReactions(cursor)
             return MediaMmsMessageRecord(
                 id, recipient, recipient,
@@ -1381,7 +1367,7 @@ class MmsDatabase(context: Context, databaseHelper: SQLCipherOpenHelper) : Messa
             val quoteId = cursor.getLong(cursor.getColumnIndexOrThrow(QUOTE_ID))
             val quoteAuthor = cursor.getString(cursor.getColumnIndexOrThrow(QUOTE_AUTHOR))
             if (quoteId == 0L || quoteAuthor.isNullOrBlank()) return null
-            val retrievedQuote = get(context).mmsSmsDatabase().getMessageFor(quoteId, quoteAuthor)
+            val retrievedQuote = get(context).mmsSmsDatabase().getMessageFor(quoteId, quoteAuthor, false)
             val quoteText = retrievedQuote?.body
             val quoteMissing = retrievedQuote == null
             val quoteDeck = (

--- a/app/src/main/java/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
@@ -97,9 +97,13 @@ public class MmsSmsDatabase extends Database {
   }
 
   public @Nullable MessageRecord getMessageFor(long timestamp, String serializedAuthor) {
+    return getMessageFor(timestamp, serializedAuthor, true);
+  }
+
+  public @Nullable MessageRecord getMessageFor(long timestamp, String serializedAuthor, boolean getQuote) {
 
     try (Cursor cursor = queryTables(PROJECTION, MmsSmsColumns.NORMALIZED_DATE_SENT + " = " + timestamp, null, null)) {
-      MmsSmsDatabase.Reader reader = readerFor(cursor);
+      MmsSmsDatabase.Reader reader = readerFor(cursor, getQuote);
 
       MessageRecord messageRecord;
       boolean isOwnNumber = Util.isOwnNumber(context, serializedAuthor);
@@ -638,7 +642,11 @@ public class MmsSmsDatabase extends Database {
   }
 
   public Reader readerFor(@NonNull Cursor cursor) {
-    return new Reader(cursor);
+    return readerFor(cursor, true);
+  }
+
+  public Reader readerFor(@NonNull Cursor cursor, boolean getQuote) {
+    return new Reader(cursor, getQuote);
   }
 
   @NotNull
@@ -661,11 +669,13 @@ public class MmsSmsDatabase extends Database {
   public class Reader implements Closeable {
 
     private final Cursor                 cursor;
+    private final boolean                getQuote;
     private       SmsDatabase.Reader     smsReader;
     private       MmsDatabase.Reader     mmsReader;
 
-    public Reader(Cursor cursor) {
+    public Reader(Cursor cursor, boolean getQuote) {
       this.cursor = cursor;
+      this.getQuote = getQuote;
     }
 
     private SmsDatabase.Reader getSmsReader() {
@@ -678,7 +688,7 @@ public class MmsSmsDatabase extends Database {
 
     private MmsDatabase.Reader getMmsReader() {
       if (mmsReader == null) {
-        mmsReader = DatabaseComponent.get(context).mmsDatabase().readerFor(cursor);
+        mmsReader = DatabaseComponent.get(context).mmsDatabase().readerFor(cursor, getQuote);
       }
 
       return mmsReader;


### PR DESCRIPTION
This PR limits database queries of messages with quotes to not fetch quotes of those quotes.

Quotes of quotes are not currently used in the app so avoiding this database query should be an easy performance improvement.