### PR TITLE
[SES-1949] Move unapprovedMessageCount to IO

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeAdapter.kt
@@ -30,6 +30,7 @@ class HomeAdapter(
 
     var messageRequests: HomeViewModel.MessageRequests? = null
         set(value) {
+            if (field == value) return
             val hadHeader = hasHeaderView()
             field = value
             if (value != null) {

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeAdapter.kt
@@ -25,11 +25,9 @@ class HomeAdapter(
 
     var header: View? = null
 
-    var data: HomeViewModel.Data = HomeViewModel.Data(emptyList(), emptySet())
+    var data: HomeViewModel.Data = HomeViewModel.Data(emptyList(), 0, false, emptySet())
         set(newData) {
-            if (field === newData) {
-                return
-            }
+            if (field === newData) return
 
             val diff = HomeDiffUtil(field, newData, context, configFactory)
             val diffResult = DiffUtil.calculateDiff(diff)

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeAdapter.kt
@@ -9,13 +9,18 @@ import androidx.recyclerview.widget.ListUpdateCallback
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.NO_ID
 import network.loki.messenger.R
+import network.loki.messenger.databinding.ViewMessageRequestBannerBinding
 import org.thoughtcrime.securesms.dependencies.ConfigFactory
 import org.thoughtcrime.securesms.mms.GlideRequests
+import org.thoughtcrime.securesms.util.DateUtils
+import java.util.Locale
 
 class HomeAdapter(
     private val context: Context,
     private val configFactory: ConfigFactory,
-    private val listener: ConversationClickListener
+    private val listener: ConversationClickListener,
+    private val showMessageRequests: () -> Unit,
+    private val hideMessageRequests: () -> Unit,
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>(), ListUpdateCallback {
 
     companion object {
@@ -23,11 +28,20 @@ class HomeAdapter(
         private const val ITEM = 1
     }
 
-    var header: View? = null
+    var messageRequests: HomeViewModel.MessageRequests? = null
+        set(value) {
+            val hadHeader = hasHeaderView()
+            field = value
+            if (value != null) {
+                if (hadHeader) notifyItemChanged(0) else notifyItemInserted(0)
+            } else if (hadHeader) notifyItemRemoved(0)
+        }
 
-    var data: HomeViewModel.Data = HomeViewModel.Data(emptyList(), 0, false, emptySet())
+    var data: HomeViewModel.Data = HomeViewModel.Data()
         set(newData) {
             if (field === newData) return
+
+            messageRequests = newData.messageRequests
 
             val diff = HomeDiffUtil(field, newData, context, configFactory)
             val diffResult = DiffUtil.calculateDiff(diff)
@@ -35,10 +49,10 @@ class HomeAdapter(
             diffResult.dispatchUpdatesTo(this as ListUpdateCallback)
         }
 
-    fun hasHeaderView(): Boolean = header != null
+    fun hasHeaderView(): Boolean = messageRequests != null
 
     private val headerCount: Int
-        get() = if (header == null) 0 else 1
+        get() = if (messageRequests == null) 0 else 1
 
     override fun onInserted(position: Int, count: Int) {
         notifyItemRangeInserted(position + headerCount, count)
@@ -67,7 +81,11 @@ class HomeAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder =
         when (viewType) {
             HEADER -> {
-                HeaderFooterViewHolder(header!!)
+                ViewMessageRequestBannerBinding.inflate(LayoutInflater.from(parent.context)).apply {
+                    root.setOnClickListener { showMessageRequests() }
+                    root.setOnLongClickListener { hideMessageRequests(); true }
+                    root.layoutParams = RecyclerView.LayoutParams(RecyclerView.LayoutParams.MATCH_PARENT, RecyclerView.LayoutParams.WRAP_CONTENT)
+                }.let(::HeaderFooterViewHolder)
             }
             ITEM -> {
                 val conversationView = LayoutInflater.from(parent.context).inflate(R.layout.view_conversation, parent, false) as ConversationView
@@ -83,19 +101,27 @@ class HomeAdapter(
         }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
-        if (holder is ConversationViewHolder) {
-            val offset = if (hasHeaderView()) position - 1 else position
-            val thread = data.threads[offset]
-            val isTyping = data.typingThreadIDs.contains(thread.threadId)
-            holder.view.bind(thread, isTyping, glide)
+        when (holder) {
+            is HeaderFooterViewHolder -> {
+                holder.binding.run {
+                    messageRequests?.let {
+                        unreadCountTextView.text = it.count
+                        timestampTextView.text = it.timestamp
+                    }
+                }
+            }
+            is ConversationViewHolder -> {
+                val offset = if (hasHeaderView()) position - 1 else position
+                val thread = data.threads[offset]
+                val isTyping = data.typingThreadIDs.contains(thread.threadId)
+                holder.view.bind(thread, isTyping, glide)
+            }
         }
     }
 
     override fun onViewRecycled(holder: RecyclerView.ViewHolder) {
         if (holder is ConversationViewHolder) {
             holder.view.recycle()
-        } else {
-            super.onViewRecycled(holder)
         }
     }
 
@@ -107,6 +133,5 @@ class HomeAdapter(
 
     class ConversationViewHolder(val view: ConversationView) : RecyclerView.ViewHolder(view)
 
-    class HeaderFooterViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
-
+    class HeaderFooterViewHolder(val binding: ViewMessageRequestBannerBinding) : RecyclerView.ViewHolder(binding.root)
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeViewModel.kt
@@ -65,6 +65,7 @@ class HomeViewModel @Inject constructor(
 
     private fun hasHiddenMessageRequests() = TextSecurePreferences.events
         .filter { it == TextSecurePreferences.HAS_HIDDEN_MESSAGE_REQUESTS }
+        .flowOn(Dispatchers.IO)
         .map { prefs.hasHiddenMessageRequests() }
         .onStart { emit(prefs.hasHiddenMessageRequests()) }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeViewModel.kt
@@ -15,11 +15,14 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.withContext
+import org.session.libsession.utilities.TextSecurePreferences
 import org.thoughtcrime.securesms.ApplicationContext
 import org.thoughtcrime.securesms.database.DatabaseContentProviders
 import org.thoughtcrime.securesms.database.ThreadDatabase
@@ -30,9 +33,10 @@ import dagger.hilt.android.qualifiers.ApplicationContext as ApplicationContextQu
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
-        private val threadDb: ThreadDatabase,
-        private val contentResolver: ContentResolver,
-        @ApplicationContextQualifier private val context: Context,
+    private val threadDb: ThreadDatabase,
+    private val contentResolver: ContentResolver,
+    private val prefs: TextSecurePreferences,
+    @ApplicationContextQualifier private val context: Context,
 ) : ViewModel() {
     // SharedFlow that emits whenever the user asks us to reload  the conversation
     private val manualReloadTrigger = MutableSharedFlow<Unit>(
@@ -46,8 +50,18 @@ class HomeViewModel @Inject constructor(
      * This flow will emit whenever the user asks us to reload the conversation list or
      * whenever the conversation list changes.
      */
-    val threads: StateFlow<Data?> = combine(observeConversationList(), observeTypingStatus(), ::Data)
-            .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+    val data: StateFlow<Data?> = combine(
+        observeConversationList(),
+        unapprovedConversationCount(),
+        hasHiddenMessageRequestsFlow(),
+        observeTypingStatus(),
+        ::Data
+    ).stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    private fun hasHiddenMessageRequestsFlow() = TextSecurePreferences.events
+        .filter { it == TextSecurePreferences.HAS_HIDDEN_MESSAGE_REQUESTS }
+        .map { prefs.hasHiddenMessageRequests() }
+        .onStart { emit(prefs.hasHiddenMessageRequests()) }
 
     private fun observeTypingStatus(): Flow<Set<Long>> =
             ApplicationContext.getInstance(context).typingStatusRepository
@@ -56,30 +70,38 @@ class HomeViewModel @Inject constructor(
                     .onStart { emit(emptySet()) }
                     .distinctUntilChanged()
 
+    private fun unapprovedConversationCount() =
+        contentResolver.observeChanges(DatabaseContentProviders.ConversationList.CONTENT_URI)
+            .flowOn(Dispatchers.IO)
+            .map { threadDb.unapprovedConversationCount }
+            .onStart { emit(threadDb.unapprovedConversationCount) }
+
     @Suppress("OPT_IN_USAGE")
     private fun observeConversationList(): Flow<List<ThreadRecord>> = merge(
-            manualReloadTrigger,
-            contentResolver.observeChanges(DatabaseContentProviders.ConversationList.CONTENT_URI))
-            .debounce(CHANGE_NOTIFICATION_DEBOUNCE_MILLS)
-            .onStart { emit(Unit) }
-            .mapLatest { _ ->
-                withContext(Dispatchers.IO) {
-                    threadDb.approvedConversationList.use { openCursor ->
-                        val reader = threadDb.readerFor(openCursor)
-                        buildList(reader.count) {
-                            while (true) {
-                                add(reader.next ?: break)
-                            }
-                        }
+        manualReloadTrigger,
+        contentResolver.observeChanges(DatabaseContentProviders.ConversationList.CONTENT_URI)
+    )
+        .flowOn(Dispatchers.IO)
+        .debounce(CHANGE_NOTIFICATION_DEBOUNCE_MILLS)
+        .onStart { emit(Unit) }
+        .mapLatest { _ ->
+            threadDb.approvedConversationList.use { openCursor ->
+                val reader = threadDb.readerFor(openCursor)
+                buildList(reader.count) {
+                    while (true) {
+                        add(reader.next ?: break)
                     }
                 }
             }
+        }
 
     fun tryReload() = manualReloadTrigger.tryEmit(Unit)
 
     data class Data(
-            val threads: List<ThreadRecord>,
-            val typingThreadIDs: Set<Long>
+        val threads: List<ThreadRecord>,
+        val unapprovedConversationCount: Int,
+        val hasHiddenMessageRequests: Boolean,
+        val typingThreadIDs: Set<Long>
     )
 
     companion object {


### PR DESCRIPTION
This is a refactor to move calls to `threadDb#unapprovedMessageCount` off of the main thread which was causing ANRs.

This PR also:

1.  fixes the binding for the messageRequests header which probably wasn't being update correctly when conversations change.
2. refactors view creating of the message requests header to the Adapter.