### PR TITLE
[SES-2162] - Remove wrapping of config message

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -78,7 +78,7 @@ local ci_dep_mirror(want_mirror) = (if want_mirror then ' -DLOCAL_MIRROR=https:/
         pull: 'always',
         environment: { SSH_KEY: { from_secret: 'SSH_KEY' }, ANDROID_HOME: '/usr/lib/android-sdk' },
         commands: [
-          'apt-get install -y ninja-build',
+          'apt-get install -y ninja-build openjdk-17-jdk-headless',
           './gradlew assemblePlayDebug',
           './scripts/drone-static-upload.sh'
         ],

--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -78,7 +78,7 @@ local ci_dep_mirror(want_mirror) = (if want_mirror then ' -DLOCAL_MIRROR=https:/
         pull: 'always',
         environment: { SSH_KEY: { from_secret: 'SSH_KEY' }, ANDROID_HOME: '/usr/lib/android-sdk' },
         commands: [
-          'apt-get install -y ninja-build openjdk-17-jdk-headless',
+          'apt-get install -y ninja-build',
           './gradlew assemblePlayDebug',
           './scripts/drone-static-upload.sh'
         ],

--- a/app/src/main/java/org/thoughtcrime/securesms/AppContext.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/AppContext.kt
@@ -1,9 +1,10 @@
 package org.thoughtcrime.securesms
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asExecutor
 import nl.komponents.kovenant.Kovenant
 import nl.komponents.kovenant.jvm.asDispatcher
 import org.session.libsignal.utilities.Log
-import org.session.libsignal.utilities.ThreadUtils
 import java.util.concurrent.Executors
 
 object AppContext {
@@ -11,7 +12,7 @@ object AppContext {
     fun configureKovenant() {
         Kovenant.context {
             callbackContext.dispatcher = Executors.newSingleThreadExecutor().asDispatcher()
-            workerContext.dispatcher = ThreadUtils.executorPool.asDispatcher()
+            workerContext.dispatcher = Dispatchers.IO.asExecutor().asDispatcher()
             multipleCompletion = { v1, v2 ->
                 Log.d("Loki", "Promise resolved more than once (first with $v1, then with $v2); ignoring $v2.")
             }

--- a/libsession/src/main/java/org/session/libsession/messaging/jobs/ConfigurationSyncJob.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/jobs/ConfigurationSyncJob.kt
@@ -67,7 +67,7 @@ data class ConfigurationSyncJob(val destination: Destination): Job {
             SharedConfigurationMessage(config.protoKindFor(), data, seqNo) to config
         }.map { (message, config) ->
             // return a list of batch request objects
-            val snodeMessage = MessageSender.buildWrappedMessageToSnode(destination, message, true)
+            val snodeMessage = MessageSender.buildConfigMessageToSnode(destination.destinationPublicKey(), message)
             val authenticated = SnodeAPI.buildAuthenticatedStoreBatchInfo(
                 destination.destinationPublicKey(),
                 config.configNamespace(),

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSender.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/MessageSender.kt
@@ -81,6 +81,15 @@ object MessageSender {
         }
     }
 
+    fun buildConfigMessageToSnode(destinationPubKey: String, message: SharedConfigurationMessage): SnodeMessage {
+        return SnodeMessage(
+            destinationPubKey,
+            Base64.encodeBytes(message.data),
+            ttl = message.ttl,
+            SnodeAPI.nowWithOffset
+        )
+    }
+
     // One-on-One Chats & Closed Groups
     @Throws(Exception::class)
     fun buildWrappedMessageToSnode(destination: Destination, message: Message, isSyncMessage: Boolean): SnodeMessage {

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/Poller.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/Poller.kt
@@ -25,6 +25,7 @@ import org.session.libsession.snode.RawResponse
 import org.session.libsession.snode.SnodeAPI
 import org.session.libsession.snode.SnodeModule
 import org.session.libsession.utilities.ConfigFactoryProtocol
+import org.session.libsignal.utilities.Base64
 import org.session.libsignal.utilities.Log
 import org.session.libsignal.utilities.Namespace
 import org.session.libsignal.utilities.Snode
@@ -126,37 +127,26 @@ class Poller(private val configFactory: ConfigFactoryProtocol, debounceTimer: Ti
     private fun processConfig(snode: Snode, rawMessages: RawResponse, namespace: Int, forConfigObject: ConfigBase?) {
         if (forConfigObject == null) return
 
-        val messages = SnodeAPI.parseRawMessagesResponse(
-            rawMessages,
-            snode,
-            userPublicKey,
-            namespace,
-            updateLatestHash = true,
-            updateStoredHashes = true,
-        )
+        val messages = rawMessages["messages"] as? List<*>
+        val processed = if (messages != null && messages.isNotEmpty()) {
+            SnodeAPI.updateLastMessageHashValueIfPossible(snode, userPublicKey, messages, namespace)
+            SnodeAPI.removeDuplicates(userPublicKey, messages, namespace, true).mapNotNull { messageBody ->
+                val rawMessageAsJSON = messageBody as? Map<*, *> ?: return@mapNotNull null
+                val hashValue = rawMessageAsJSON["hash"] as? String ?: return@mapNotNull null
+                val b64EncodedBody = rawMessageAsJSON["data"] as? String ?: return@mapNotNull null
+                val timestamp = rawMessageAsJSON["t"] as? Long ?: SnodeAPI.nowWithOffset
+                val body = Base64.decode(b64EncodedBody)
+                Triple(body, hashValue, timestamp)
+            }
+        } else emptyList()
 
-        if (messages.isEmpty()) {
-            // no new messages to process
-            return
-        }
+        if (processed.isEmpty()) return
 
         var latestMessageTimestamp: Long? = null
-        messages.forEach { (envelope, hash) ->
+        processed.forEach { (body, hash, timestamp) ->
             try {
-                val (message, _) = MessageReceiver.parse(data = envelope.toByteArray(),
-                    // assume no groups in personal poller messages
-                    openGroupServerID = null, currentClosedGroups = emptySet()
-                )
-                // sanity checks
-                if (message !is SharedConfigurationMessage) {
-                    Log.w("Loki", "shared config message handled in configs wasn't SharedConfigurationMessage but was ${message.javaClass.simpleName}")
-                    return@forEach
-                }
-                val merged = forConfigObject.merge(hash!! to message.data).firstOrNull { it == hash }
-                if (merged != null) {
-                    // We successfully merged the hash, we can now update the timestamp
-                    latestMessageTimestamp = if ((message.sentTimestamp ?: 0L) > (latestMessageTimestamp ?: 0L)) { message.sentTimestamp } else { latestMessageTimestamp }
-                }
+                forConfigObject.merge(hash to body)
+                latestMessageTimestamp = if (timestamp > (latestMessageTimestamp ?: 0L)) { timestamp } else { latestMessageTimestamp }
             } catch (e: Exception) {
                 Log.e("Loki", e)
             }

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/Poller.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/pollers/Poller.kt
@@ -128,7 +128,7 @@ class Poller(private val configFactory: ConfigFactoryProtocol, debounceTimer: Ti
         if (forConfigObject == null) return
 
         val messages = rawMessages["messages"] as? List<*>
-        val processed = if (messages != null && messages.isNotEmpty()) {
+        val processed = if (!messages.isNullOrEmpty()) {
             SnodeAPI.updateLastMessageHashValueIfPossible(snode, userPublicKey, messages, namespace)
             SnodeAPI.removeDuplicates(userPublicKey, messages, namespace, true).mapNotNull { messageBody ->
                 val rawMessageAsJSON = messageBody as? Map<*, *> ?: return@mapNotNull null

--- a/libsession/src/main/java/org/session/libsession/snode/SnodeAPI.kt
+++ b/libsession/src/main/java/org/session/libsession/snode/SnodeAPI.kt
@@ -829,7 +829,7 @@ object SnodeAPI {
         }
     }
 
-    private fun updateLastMessageHashValueIfPossible(snode: Snode, publicKey: String, rawMessages: List<*>, namespace: Int) {
+    fun updateLastMessageHashValueIfPossible(snode: Snode, publicKey: String, rawMessages: List<*>, namespace: Int) {
         val lastMessageAsJSON = rawMessages.lastOrNull() as? Map<*, *>
         val hashValue = lastMessageAsJSON?.get("hash") as? String
         if (hashValue != null) {
@@ -839,7 +839,7 @@ object SnodeAPI {
         }
     }
 
-    private fun removeDuplicates(publicKey: String, rawMessages: List<*>, namespace: Int, updateStoredHashes: Boolean): List<*> {
+    fun removeDuplicates(publicKey: String, rawMessages: List<*>, namespace: Int, updateStoredHashes: Boolean): List<*> {
         val originalMessageHashValues = database.getReceivedMessageHashValues(publicKey, namespace)?.toMutableSet() ?: mutableSetOf()
         val receivedMessageHashValues = originalMessageHashValues.toMutableSet()
         val result = rawMessages.filter { rawMessage ->

--- a/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
+++ b/libsignal/src/main/java/org/session/libsignal/utilities/ThreadUtils.kt
@@ -1,11 +1,13 @@
 package org.session.libsignal.utilities
 
 import android.os.Process
+import kotlinx.coroutines.Dispatchers
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.SynchronousQueue
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
+import kotlin.coroutines.EmptyCoroutineContext
 
 object ThreadUtils {
 
@@ -13,39 +15,16 @@ object ThreadUtils {
 
     const val PRIORITY_IMPORTANT_BACKGROUND_THREAD = Process.THREAD_PRIORITY_DEFAULT + Process.THREAD_PRIORITY_LESS_FAVORABLE
 
-    // Paraphrased from: https://www.baeldung.com/kotlin/create-thread-pool
-    // "A cached thread pool such as one created via:
-    // `val executorPool: ExecutorService = Executors.newCachedThreadPool()`
-    // will utilize resources according to the requirements of submitted tasks. It will try to reuse
-    // existing threads for submitted tasks but will create as many threads as it needs if new tasks
-    // keep pouring in (with a memory usage of at least 1MB per created thread). These threads will
-    // live for up to 60 seconds of idle time before terminating by default. As such, it presents a
-    // very sharp tool that doesn't include any backpressure mechanism - and a sudden peak in load
-    // can bring the system down with an OutOfMemory error. We can achieve a similar effect but with
-    // better control by creating a ThreadPoolExecutor manually."
-
-    private val corePoolSize      = Runtime.getRuntime().availableProcessors() // Default thread pool size is our CPU core count
-    private val maxPoolSize       = corePoolSize * 4                           // Allow a maximum pool size of up to 4 threads per core
-    private val keepAliveTimeSecs = 100L                                       // How long to keep idle threads in the pool before they are terminated
-    private val workQueue         = SynchronousQueue<Runnable>()
-    val executorPool: ExecutorService = ThreadPoolExecutor(corePoolSize, maxPoolSize, keepAliveTimeSecs, TimeUnit.SECONDS, workQueue)
-
     // Note: To see how many threads are running in our app at any given time we can use:
     // val threadCount = getAllStackTraces().size
 
     @JvmStatic
     fun queue(target: Runnable) {
-        executorPool.execute {
-            try {
-                target.run()
-            } catch (e: Exception) {
-                Log.e(TAG, e)
-            }
-        }
+        queue(target::run)
     }
 
     fun queue(target: () -> Unit) {
-        executorPool.execute {
+        Dispatchers.IO.dispatch(EmptyCoroutineContext) {
             try {
                 target()
             } catch (e: Exception) {


### PR DESCRIPTION
**Background**

_tldr; Android is doing incorrect config message encoding._

Sometime in the past, any user's config update (like what groups they subscribed to, contacts, etc) will be pushed into the swarm as "messages", just like any other messages the user may see, but with a different type. Because they all push into the same place, when the user tries to restore their account, as all the messages are stored and restored in date sequential order, the user might not get the "config message" in time, if not at all.

To fix the problem, we introduced the concept of `namespaces`, essentially pre-defined constants with meaning. Like `GROUPS` namespace dictates that the messages should be group config messages.  By doing this important messages like config messages won't get swamped along side other normal user messages, this improve the reliability greatly.

As a side effect coming out from the namespace changes, we can know in advance what the message format is for a given namespace. This eliminates the need to use `protobuf`: where different  types of messages are serialised together.

So we did move away from the protobuf for the config messages (regular messages still use protobuf!). However, Android codebase still keeps using protobuf for the config messages, this causes trouble for the other clients who no longer use protobuf, as those clients won't be able to decode the protobuf-wrapped messages.

**This PR:**

1. Removes the wrapping/unwrapping of the config messages on the client side, any config message serialisation is now handed over entirely to `libsession`
2. Update `libsession` so that it can handle already-wrapped messages that exist in the wild, so that existing users' configs are preserved.

**Note**
This PR is a temporarily fix for the current production. The config system has been reworked on the groups branch and once that one is about to be merged, all changes here can be discarded first.