### PR TITLE
Remove config checks (PR 1294)

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/ConfigFactory.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/ConfigFactory.kt
@@ -7,7 +7,6 @@ import network.loki.messenger.libsession_util.Contacts
 import network.loki.messenger.libsession_util.ConversationVolatileConfig
 import network.loki.messenger.libsession_util.UserGroupsConfig
 import network.loki.messenger.libsession_util.UserProfile
-import org.session.libsession.snode.SnodeAPI
 import org.session.libsession.utilities.ConfigFactoryProtocol
 import org.session.libsession.utilities.ConfigFactoryUpdateListener
 import org.session.libsession.utilities.TextSecurePreferences
@@ -72,7 +71,6 @@ class ConfigFactory(
 
     override val user: UserProfile?
         get() = synchronizedWithLog(userLock) {
-            if (!ConfigBase.isNewConfigEnabled(isConfigForcedOn, SnodeAPI.nowWithOffset)) return null
             if (_userConfig == null) {
                 val (secretKey, publicKey) = maybeGetUserInfo() ?: return null
                 val userDump = configDatabase.retrieveConfigAndHashes(
@@ -92,7 +90,6 @@ class ConfigFactory(
 
     override val contacts: Contacts?
         get() = synchronizedWithLog(contactsLock) {
-            if (!ConfigBase.isNewConfigEnabled(isConfigForcedOn, SnodeAPI.nowWithOffset)) return null
             if (_contacts == null) {
                 val (secretKey, publicKey) = maybeGetUserInfo() ?: return null
                 val contactsDump = configDatabase.retrieveConfigAndHashes(
@@ -112,7 +109,6 @@ class ConfigFactory(
 
     override val convoVolatile: ConversationVolatileConfig?
         get() = synchronizedWithLog(convoVolatileLock) {
-            if (!ConfigBase.isNewConfigEnabled(isConfigForcedOn, SnodeAPI.nowWithOffset)) return null
             if (_convoVolatileConfig == null) {
                 val (secretKey, publicKey) = maybeGetUserInfo() ?: return null
                 val convoDump = configDatabase.retrieveConfigAndHashes(
@@ -133,7 +129,6 @@ class ConfigFactory(
 
     override val userGroups: UserGroupsConfig?
         get() = synchronizedWithLog(userGroupsLock) {
-            if (!ConfigBase.isNewConfigEnabled(isConfigForcedOn, SnodeAPI.nowWithOffset)) return null
             if (_userGroups == null) {
                 val (secretKey, publicKey) = maybeGetUserInfo() ?: return null
                 val userGroupsDump = configDatabase.retrieveConfigAndHashes(
@@ -207,8 +202,6 @@ class ConfigFactory(
         openGroupId: String?,
         visibleOnly: Boolean
     ): Boolean {
-        if (!ConfigBase.isNewConfigEnabled(isConfigForcedOn, SnodeAPI.nowWithOffset)) return true
-
         val (_, userPublicKey) = maybeGetUserInfo() ?: return true
 
         if (openGroupId != null) {
@@ -241,8 +234,6 @@ class ConfigFactory(
     }
 
     override fun canPerformChange(variant: String, publicKey: String, changeTimestampMs: Long): Boolean {
-        if (!ConfigBase.isNewConfigEnabled(isConfigForcedOn, SnodeAPI.nowWithOffset)) return true
-
         val lastUpdateTimestampMs = configDatabase.retrieveConfigLastUpdateTimestamp(variant, publicKey)
 
         // Ensure the change occurred after the last config message was handled (minus the buffer period)

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import network.loki.messenger.R
 import network.loki.messenger.databinding.ActivityHomeBinding
-import network.loki.messenger.libsession_util.ConfigBase
 import org.greenrobot.eventbus.EventBus
 import org.greenrobot.eventbus.Subscribe
 import org.greenrobot.eventbus.ThreadMode
@@ -336,8 +335,7 @@ class HomeActivity : PassphraseRequiredActionBarActivity(),
     }
 
     private fun updateLegacyConfigView() {
-        binding.configOutdatedView.isVisible = ConfigBase.isNewConfigEnabled(textSecurePreferences.hasForcedNewConfig(), SnodeAPI.nowWithOffset)
-                && textSecurePreferences.getHasLegacyConfig()
+        binding.configOutdatedView.isVisible = textSecurePreferences.getHasLegacyConfig()
     }
 
     override fun onResume() {

--- a/app/src/main/java/org/thoughtcrime/securesms/util/ConfigurationMessageUtilities.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/ConfigurationMessageUtilities.kt
@@ -17,8 +17,6 @@ import org.session.libsession.messaging.jobs.ConfigurationSyncJob
 import org.session.libsession.messaging.jobs.JobQueue
 import org.session.libsession.messaging.messages.Destination
 import org.session.libsession.messaging.messages.control.ConfigurationMessage
-import org.session.libsession.messaging.sending_receiving.MessageSender
-import org.session.libsession.snode.SnodeAPI
 import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.GroupUtil
 import org.session.libsession.utilities.TextSecurePreferences
@@ -55,61 +53,16 @@ object ConfigurationMessageUtilities {
     fun syncConfigurationIfNeeded(context: Context) {
         // add if check here to schedule new config job process and return early
         val userPublicKey = TextSecurePreferences.getLocalNumber(context) ?: return
-        val forcedConfig = TextSecurePreferences.hasForcedNewConfig(context)
-        val currentTime = SnodeAPI.nowWithOffset
-        if (ConfigBase.isNewConfigEnabled(forcedConfig, currentTime)) {
-            scheduleConfigSync(userPublicKey)
-            return
-        }
-        val lastSyncTime = TextSecurePreferences.getLastConfigurationSyncTime(context)
-        val now = System.currentTimeMillis()
-        if (now - lastSyncTime < 7 * 24 * 60 * 60 * 1000) return
-        val contacts = ContactUtilities.getAllContacts(context).filter { recipient ->
-            !recipient.name.isNullOrEmpty() && !recipient.isLocalNumber && recipient.address.serialize().isNotEmpty()
-        }.map { recipient ->
-            ConfigurationMessage.Contact(
-                publicKey = recipient.address.serialize(),
-                name = recipient.name!!,
-                profilePicture = recipient.profileAvatar,
-                profileKey = recipient.profileKey,
-                isApproved = recipient.isApproved,
-                isBlocked = recipient.isBlocked,
-                didApproveMe = recipient.hasApprovedMe()
-            )
-        }
-        val configurationMessage = ConfigurationMessage.getCurrent(contacts) ?: return
-        MessageSender.send(configurationMessage, Address.fromSerialized(userPublicKey))
-        TextSecurePreferences.setLastConfigurationSyncTime(context, now)
+        scheduleConfigSync(userPublicKey)
     }
 
     fun forceSyncConfigurationNowIfNeeded(context: Context): Promise<Unit, Exception> {
         // add if check here to schedule new config job process and return early
         val userPublicKey = TextSecurePreferences.getLocalNumber(context) ?: return Promise.ofFail(NullPointerException("User Public Key is null"))
-        val forcedConfig = TextSecurePreferences.hasForcedNewConfig(context)
-        val currentTime = SnodeAPI.nowWithOffset
-        if (ConfigBase.isNewConfigEnabled(forcedConfig, currentTime)) {
-            // schedule job if none exist
-            // don't schedule job if we already have one
-            scheduleConfigSync(userPublicKey)
-            return Promise.ofSuccess(Unit)
-        }
-        val contacts = ContactUtilities.getAllContacts(context).filter { recipient ->
-            !recipient.isGroupRecipient && !recipient.name.isNullOrEmpty() && !recipient.isLocalNumber && recipient.address.serialize().isNotEmpty()
-        }.map { recipient ->
-            ConfigurationMessage.Contact(
-                publicKey = recipient.address.serialize(),
-                name = recipient.name!!,
-                profilePicture = recipient.profileAvatar,
-                profileKey = recipient.profileKey,
-                isApproved = recipient.isApproved,
-                isBlocked = recipient.isBlocked,
-                didApproveMe = recipient.hasApprovedMe()
-            )
-        }
-        val configurationMessage = ConfigurationMessage.getCurrent(contacts) ?: return Promise.ofSuccess(Unit)
-        val promise = MessageSender.send(configurationMessage, Destination.from(Address.fromSerialized(userPublicKey)), isSyncMessage = true)
-        TextSecurePreferences.setLastConfigurationSyncTime(context, System.currentTimeMillis())
-        return promise
+        // schedule job if none exist
+        // don't schedule job if we already have one
+        scheduleConfigSync(userPublicKey)
+        return Promise.ofSuccess(Unit)
     }
 
     private fun maybeUserSecretKey() = MessagingModuleConfiguration.shared.getUserED25519KeyPair()?.secretKey?.asBytes

--- a/libsession-util/src/main/java/network/loki/messenger/libsession_util/Config.kt
+++ b/libsession-util/src/main/java/network/loki/messenger/libsession_util/Config.kt
@@ -27,12 +27,6 @@ sealed class ConfigBase(protected val /* yucky */ pointer: Long) {
             is UserGroupsConfig -> Kind.GROUPS
         }
 
-        // TODO: time in future to activate (hardcoded to 1st jan 2024 for testing, change before release)
-        private const val ACTIVATE_TIME = 1690761600000
-
-        fun isNewConfigEnabled(forced: Boolean, currentTime: Long) =
-            forced || currentTime >= ACTIVATE_TIME
-
         const val PRIORITY_HIDDEN = -1
         const val PRIORITY_VISIBLE = 0
         const val PRIORITY_PINNED = 1

--- a/libsession/src/main/java/org/session/libsession/messaging/jobs/ConfigurationSyncJob.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/jobs/ConfigurationSyncJob.kt
@@ -1,6 +1,5 @@
 package org.session.libsession.messaging.jobs
 
-import network.loki.messenger.libsession_util.ConfigBase
 import network.loki.messenger.libsession_util.ConfigBase.Companion.protoKindFor
 import nl.komponents.kovenant.functional.bind
 import org.session.libsession.messaging.MessagingModuleConfiguration
@@ -10,7 +9,6 @@ import org.session.libsession.messaging.sending_receiving.MessageSender
 import org.session.libsession.messaging.utilities.Data
 import org.session.libsession.snode.RawResponse
 import org.session.libsession.snode.SnodeAPI
-import org.session.libsession.utilities.TextSecurePreferences
 import org.session.libsignal.utilities.Log
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -26,14 +24,10 @@ data class ConfigurationSyncJob(val destination: Destination): Job {
 
     override suspend fun execute(dispatcherName: String) {
         val storage = MessagingModuleConfiguration.shared.storage
-        val forcedConfig = TextSecurePreferences.hasForcedNewConfig(MessagingModuleConfiguration.shared.context)
-        val currentTime = SnodeAPI.nowWithOffset
         val userEdKeyPair = MessagingModuleConfiguration.shared.getUserED25519KeyPair()
         val userPublicKey = storage.getUserPublicKey()
         val delegate = delegate
-        if (destination is Destination.ClosedGroup // TODO: closed group configs will be handled in closed group feature
-            // if we haven't enabled the new configs don't run
-            || !ConfigBase.isNewConfigEnabled(forcedConfig, currentTime)
+        if (destination is Destination.ClosedGroup
             // if we don't have a user ed key pair for signing updates
             || userEdKeyPair == null
             // this will be useful to not handle null delegate cases

--- a/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/ReceivedMessageHandler.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/sending_receiving/ReceivedMessageHandler.kt
@@ -203,12 +203,10 @@ private fun handleConfigurationMessage(message: ConfigurationMessage) {
 
     TextSecurePreferences.setConfigurationMessageSynced(context, true)
     TextSecurePreferences.setLastProfileUpdateTime(context, message.sentTimestamp!!)
-    val isForceSync = TextSecurePreferences.hasForcedNewConfig(context)
-    val currentTime = SnodeAPI.nowWithOffset
-    if (ConfigBase.isNewConfigEnabled(isForceSync, currentTime)) {
-        TextSecurePreferences.setHasLegacyConfig(context, true)
-        if (!firstTimeSync) return
-    }
+
+    TextSecurePreferences.setHasLegacyConfig(context, true)
+    if (!firstTimeSync) return
+
     val allClosedGroupPublicKeys = storage.getAllClosedGroupPublicKeys()
     for (closedGroup in message.closedGroups) {
         if (allClosedGroupPublicKeys.contains(closedGroup.publicKey)) {


### PR DESCRIPTION
Refactor: remove checks for whether new config is enabled throughout config factory generation. 

This is using the changes from the first commit of this PR:
https://github.com/oxen-io/session-android/pull/1294

