### PR TITLE
Allow "public.loki.foundation" to be accessed by http

### DIFF
--- a/app/src/main/res/xml/network_security_configuration.xml
+++ b/app/src/main/res/xml/network_security_configuration.xml
@@ -2,6 +2,7 @@
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">127.0.0.1</domain>
+        <domain includeSubdomains="true">public.loki.foundation</domain>
     </domain-config>
     <domain-config cleartextTrafficPermitted="false">
         <domain includeSubdomains="false">seed1.getsession.org</domain>


### PR DESCRIPTION
This URL is only actually assessed by testnet builds