### PR TITLE
SES2397 - Fix display name change fail feedback

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/ProfilePictureView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ProfilePictureView.kt
@@ -88,7 +88,7 @@ class ProfilePictureView @JvmOverloads constructor(
     }
 
     fun update() {
-        val publicKey = publicKey ?: return Log.w(TAG, "Cannot update profile picture without a public key")
+        val publicKey = publicKey ?: return Log.i(TAG, "Profile picture lacks a public key - if we were removing the profile picture this is not a problem.")
         val additionalPublicKey = additionalPublicKey
         if (additionalPublicKey != null) {
             setProfilePictureIfNeeded(binding.doubleModeImageView1, publicKey, displayName)

--- a/app/src/main/java/org/thoughtcrime/securesms/components/ProfilePictureView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ProfilePictureView.kt
@@ -17,6 +17,7 @@ import org.session.libsession.messaging.contacts.Contact
 import org.session.libsession.utilities.Address
 import org.session.libsession.utilities.GroupUtil
 import org.session.libsession.utilities.recipients.Recipient
+import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
 import org.thoughtcrime.securesms.mms.GlideApp
 import org.thoughtcrime.securesms.mms.GlideRequests
@@ -24,6 +25,8 @@ import org.thoughtcrime.securesms.mms.GlideRequests
 class ProfilePictureView @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null
 ) : RelativeLayout(context, attrs) {
+    private val TAG = "ProfilePictureView"
+
     private val binding = ViewProfilePictureBinding.inflate(LayoutInflater.from(context), this)
     private val glide: GlideRequests = GlideApp.with(this)
     var publicKey: String? = null
@@ -85,7 +88,7 @@ class ProfilePictureView @JvmOverloads constructor(
     }
 
     fun update() {
-        val publicKey = publicKey ?: return
+        val publicKey = publicKey ?: return Log.w(TAG, "Cannot update profile picture without a public key")
         val additionalPublicKey = additionalPublicKey
         if (additionalPublicKey != null) {
             setProfilePictureIfNeeded(binding.doubleModeImageView1, publicKey, displayName)

--- a/app/src/main/java/org/thoughtcrime/securesms/components/ProfilePictureView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ProfilePictureView.kt
@@ -88,7 +88,7 @@ class ProfilePictureView @JvmOverloads constructor(
     }
 
     fun update() {
-        val publicKey = publicKey ?: return Log.i(TAG, "Profile picture lacks a public key - if we were removing the profile picture this is not a problem.")
+        val publicKey = publicKey ?: return Log.w(TAG, "Could not find public key to update profile picture")
         val additionalPublicKey = additionalPublicKey
         if (additionalPublicKey != null) {
             setProfilePictureIfNeeded(binding.doubleModeImageView1, publicKey, displayName)


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have tested my contribution on these devices:
 * Virtual Pixel 3a, Android 14, API 34
- [X] My contribution is fully baked and ready to be merged as is
~~- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)~~

----------

### Description
This ticket is a QA subtask based on SES-2168 where it was found in QA that attempting to change the user's display name without a valid Internet connection performed the update locally, but left the 'updating' 3-dots animation running which the user then had to 'back' out of. This PR modifies that behaviour so that the relevant "Unable to update profile" Toast is displayed under the following circumstances:
- The device has no valid internet connection and hence cannot possibly sync the updated profile name,
- No display name is provided (this is already null checked before it gets to us, but 'defense in layers' etc.), or
- We were unable to access the configFactory `user` object in order to update the display name.

Should none of the above three criteria be met then the display name update is performed, the 'updating' animation is removed, and the updated display name is displayed  in the Settings activity.
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
