### PR TITLE
Add testnet build flag

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsActivity.kt
@@ -26,6 +26,8 @@ import java.io.File
 import java.security.SecureRandom
 import javax.inject.Inject
 import network.loki.messenger.BuildConfig
+import network.loki.messenger.BuildConfig.VERSION_CODE
+import network.loki.messenger.BuildConfig.VERSION_NAME
 import network.loki.messenger.R
 import network.loki.messenger.databinding.ActivitySettingsBinding
 import network.loki.messenger.libsession_util.util.UserPic
@@ -111,7 +113,8 @@ class SettingsActivity : PassphraseRequiredActionBarActivity() {
             clearAllDataButton.setOnClickListener { clearAllData() }
 
             val gitCommitFirstSixChars = BuildConfig.GIT_HASH.take(6)
-            versionTextView.text = String.format(getString(R.string.version_s), "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE} - $gitCommitFirstSixChars)")
+            val isTestNetString = if (org.session.libsession.BuildConfig.USE_TESTNET) " testnet" else ""
+            versionTextView.text = String.format(getString(R.string.version_s), "$VERSION_NAME ($VERSION_CODE - $gitCommitFirstSixChars)$isTestNetString")
         }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/SettingsActivity.kt
@@ -35,6 +35,7 @@ import nl.komponents.kovenant.Promise
 import nl.komponents.kovenant.ui.alwaysUi
 import nl.komponents.kovenant.ui.failUi
 import nl.komponents.kovenant.ui.successUi
+import org.session.libsession.BuildConfig.USE_TESTNET
 import org.session.libsession.avatars.AvatarHelper
 import org.session.libsession.avatars.ProfileContactPhoto
 import org.session.libsession.messaging.MessagingModuleConfiguration
@@ -114,7 +115,7 @@ class SettingsActivity : PassphraseRequiredActionBarActivity() {
             clearAllDataButton.setOnClickListener { clearAllData() }
 
             val gitCommitFirstSixChars = BuildConfig.GIT_HASH.take(6)
-            val isTestNetString = if (org.session.libsession.BuildConfig.USE_TESTNET) " testnet" else ""
+            val isTestNetString = if (USE_TESTNET) " testnet" else ""
             versionTextView.text = String.format(getString(R.string.version_s), "$VERSION_NAME ($VERSION_CODE - $gitCommitFirstSixChars)$isTestNetString")
         }
     }

--- a/libsession/build.gradle
+++ b/libsession/build.gradle
@@ -9,6 +9,10 @@ android {
 
     defaultConfig {
         minSdkVersion androidMinimumSdkVersion
+
+
+        def useTestnet = project.hasProperty('testnet')
+        buildConfigField "boolean", "USE_TESTNET", "$useTestnet"
     }
 
     compileOptions {

--- a/libsession/build.gradle
+++ b/libsession/build.gradle
@@ -10,7 +10,6 @@ android {
     defaultConfig {
         minSdkVersion androidMinimumSdkVersion
 
-
         def useTestnet = project.hasProperty('testnet')
         buildConfigField "boolean", "USE_TESTNET", "$useTestnet"
     }

--- a/libsession/src/main/java/org/session/libsession/snode/SnodeAPI.kt
+++ b/libsession/src/main/java/org/session/libsession/snode/SnodeAPI.kt
@@ -15,6 +15,7 @@ import nl.komponents.kovenant.deferred
 import nl.komponents.kovenant.functional.bind
 import nl.komponents.kovenant.functional.map
 import nl.komponents.kovenant.task
+import org.session.libsession.BuildConfig
 import org.session.libsession.messaging.MessagingModuleConfiguration
 import org.session.libsession.messaging.utilities.MessageWrapper
 import org.session.libsession.messaging.utilities.SodiumUtilities.sodium
@@ -73,7 +74,7 @@ object SnodeAPI {
     // Use port 4433 if the API level can handle the network security configuration and enforce pinned certificates
     private val seedNodePort = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) 443 else 4443
     private val seedNodePool by lazy {
-        if (useTestnet) {
+        if (BuildConfig.USE_TESTNET) {
             setOf( "http://public.loki.foundation:38157" )
         } else {
             setOf(
@@ -85,8 +86,6 @@ object SnodeAPI {
     }
     private const val snodeFailureThreshold = 3
     private const val useOnionRequests = true
-
-    const val useTestnet = false
 
     // Error
     internal sealed class Error(val description: String) : Exception(description) {


### PR DESCRIPTION
Pass in `-testnet` or `-Ptestnet` in Android Studio to set the app to use `testnet`.

testnet is `http://public.loki.foundation:38157`

Otherwise we use the usual seed nodes, usually these:

```
https://seed1.getsession.org:4443
https://seed2.getsession.org:4443
https://seed3.getsession.org:4443
```