### PR TITLE
Replace kapt with ksp and update dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,22 +10,19 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlinVersion"
         classpath "com.google.gms:google-services:$googleServicesVersion"
-        classpath "com.google.dagger:hilt-android-gradle-plugin:$daggerVersion"
     }
 }
 
 plugins {
-    id 'kotlin-kapt'
+    id 'com.google.devtools.ksp'
     id 'com.google.dagger.hilt.android'
 }
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'witness'
-apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlinx-serialization'
-apply plugin: 'dagger.hilt.android.plugin'
 
 configurations.all {
     exclude module: "commons-logging"
@@ -89,7 +86,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.7'
+        kotlinCompilerExtensionVersion '1.5.14'
     }
 
     defaultConfig {
@@ -239,8 +236,9 @@ android {
 
 dependencies {
 
-    implementation("com.google.dagger:hilt-android:2.46.1")
-    kapt("com.google.dagger:hilt-android-compiler:2.44")
+    implementation("com.google.dagger:hilt-android:$daggerHiltVersion")
+    ksp("com.google.dagger:hilt-compiler:$daggerHiltVersion")
+    ksp("androidx.hilt:hilt-compiler:$jetpackHiltVersion")
 
     implementation "androidx.appcompat:appcompat:$appcompatVersion"
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
@@ -281,8 +279,7 @@ dependencies {
     implementation 'commons-net:commons-net:3.7.2'
     implementation 'com.github.chrisbanes:PhotoView:2.1.3'
     implementation "com.github.bumptech.glide:glide:$glideVersion"
-    annotationProcessor "com.github.bumptech.glide:compiler:$glideVersion"
-    kapt "com.github.bumptech.glide:compiler:$glideVersion"
+    ksp "com.github.bumptech.glide:ksp:$glideVersion"
     implementation 'com.makeramen:roundedimageview:2.1.0'
     implementation 'com.pnikosis:materialish-progress:1.5'
     implementation 'org.greenrobot:eventbus:3.0.0'
@@ -290,8 +287,6 @@ dependencies {
     implementation 'com.theartofdev.edmodo:android-image-cropper:2.8.0'
     implementation 'com.melnykov:floatingactionbutton:1.3.0'
     implementation 'com.google.zxing:android-integration:3.1.0'
-    implementation "com.google.dagger:hilt-android:$daggerVersion"
-    kapt "com.google.dagger:hilt-compiler:$daggerVersion"
     implementation 'mobi.upod:time-duration-picker:1.1.3'
     implementation 'com.google.zxing:core:3.2.1'
     implementation ('com.davemorrissey.labs:subsampling-scale-image-view:3.6.0') {
@@ -414,9 +409,4 @@ def autoResConfig() {
          .findAll { matcher -> matcher.find() }
          .collect { matcher -> matcher.group(1) }
          .sort()
-}
-
-// Allow references to generated code
-kapt {
-    correctErrorTypes = true
 }

--- a/app/src/androidTest/java/network/loki/messenger/HomeActivityTests.kt
+++ b/app/src/androidTest/java/network/loki/messenger/HomeActivityTests.kt
@@ -40,7 +40,7 @@ import org.session.libsignal.utilities.guava.Optional
 import org.thoughtcrime.securesms.conversation.v2.ConversationActivityV2
 import org.thoughtcrime.securesms.conversation.v2.input_bar.InputBar
 import org.thoughtcrime.securesms.home.HomeActivity
-import org.thoughtcrime.securesms.mms.GlideApp
+import com.bumptech.glide.Glide
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
@@ -71,7 +71,7 @@ class HomeActivityTests {
         onView(allOf(isDescendantOfA(withId(R.id.inputBar)),withId(R.id.inputBarEditText))).perform(ViewActions.replaceText(messageToSend))
         if (linkPreview != null) {
             val activity = activityMonitor.waitForActivity() as ConversationActivityV2
-            val glide = GlideApp.with(activity)
+            val glide = Glide.with(activity)
             activity.findViewById<InputBar>(R.id.inputBar).updateLinkPreviewDraft(glide, linkPreview)
         }
         onView(allOf(isDescendantOfA(withId(R.id.inputBar)),inputButtonWithDrawable(R.drawable.ic_arrow_up))).perform(ViewActions.click())

--- a/app/src/main/java/org/thoughtcrime/securesms/MediaGalleryAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/MediaGalleryAdapter.java
@@ -29,7 +29,7 @@ import com.codewaves.stickyheadergrid.StickyHeaderGridAdapter;
 import org.thoughtcrime.securesms.conversation.v2.utilities.ThumbnailView;
 import org.thoughtcrime.securesms.database.MediaDatabase.MediaRecord;
 import org.thoughtcrime.securesms.database.loaders.BucketedThreadMediaLoader.BucketedThreadMedia;
-import org.thoughtcrime.securesms.mms.GlideRequests;
+import com.bumptech.glide.RequestManager;
 import org.thoughtcrime.securesms.mms.Slide;
 import org.thoughtcrime.securesms.util.MediaUtil;
 
@@ -46,7 +46,7 @@ class MediaGalleryAdapter extends StickyHeaderGridAdapter {
   private static final String TAG = MediaGalleryAdapter.class.getSimpleName();
 
   private final Context             context;
-  private final GlideRequests glideRequests;
+  private final RequestManager glideRequests;
   private final Locale              locale;
   private final ItemClickListener   itemClickListener;
   private final Set<MediaRecord>    selected;
@@ -74,7 +74,7 @@ class MediaGalleryAdapter extends StickyHeaderGridAdapter {
   }
 
   MediaGalleryAdapter(@NonNull Context context,
-                      @NonNull GlideRequests glideRequests,
+                      @NonNull RequestManager glideRequests,
                       BucketedThreadMedia media,
                       Locale locale,
                       ItemClickListener clickListener)

--- a/app/src/main/java/org/thoughtcrime/securesms/MediaOverviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/MediaOverviewActivity.java
@@ -61,7 +61,7 @@ import org.thoughtcrime.securesms.database.MediaDatabase;
 import org.thoughtcrime.securesms.database.loaders.BucketedThreadMediaLoader;
 import org.thoughtcrime.securesms.database.loaders.BucketedThreadMediaLoader.BucketedThreadMedia;
 import org.thoughtcrime.securesms.database.loaders.ThreadMediaLoader;
-import org.thoughtcrime.securesms.mms.GlideApp;
+import com.bumptech.glide.Glide;
 import org.thoughtcrime.securesms.permissions.Permissions;
 import org.session.libsession.utilities.recipients.Recipient;
 import org.thoughtcrime.securesms.util.AttachmentUtil;
@@ -227,7 +227,7 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity {
       this.gridManager  = new StickyHeaderGridLayoutManager(getResources().getInteger(R.integer.media_overview_cols));
 
       this.recyclerView.setAdapter(new MediaGalleryAdapter(getContext(),
-                                                           GlideApp.with(this),
+                                                           Glide.with(this),
                                                            new BucketedThreadMedia(getContext()),
                                                            locale,
                                                            this));

--- a/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -72,8 +72,8 @@ import org.thoughtcrime.securesms.database.loaders.PagingMediaLoader;
 import org.thoughtcrime.securesms.database.model.MmsMessageRecord;
 import org.thoughtcrime.securesms.mediapreview.MediaPreviewViewModel;
 import org.thoughtcrime.securesms.mediapreview.MediaRailAdapter;
-import org.thoughtcrime.securesms.mms.GlideApp;
-import org.thoughtcrime.securesms.mms.GlideRequests;
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.RequestManager;
 import org.thoughtcrime.securesms.mms.Slide;
 import org.thoughtcrime.securesms.permissions.Permissions;
 import org.thoughtcrime.securesms.util.AttachmentUtil;
@@ -281,7 +281,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     mediaPager.setOffscreenPageLimit(1);
 
     albumRail        = findViewById(R.id.media_preview_album_rail);
-    albumRailAdapter = new MediaRailAdapter(GlideApp.with(this), this, false);
+    albumRailAdapter = new MediaRailAdapter(Glide.with(this), this, false);
 
     albumRail.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false));
     albumRail.setAdapter(albumRailAdapter);
@@ -370,7 +370,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     if (conversationRecipient != null) {
       getSupportLoaderManager().restartLoader(0, null, this);
     } else {
-      adapter = new SingleItemPagerAdapter(this, GlideApp.with(this), getWindow(), initialMediaUri, initialMediaType, initialMediaSize);
+      adapter = new SingleItemPagerAdapter(this, Glide.with(this), getWindow(), initialMediaUri, initialMediaType, initialMediaSize);
       mediaPager.setAdapter(adapter);
 
       if (initialCaption != null) {
@@ -518,7 +518,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
 
     mediaPager.removeOnPageChangeListener(viewPagerListener);
 
-    adapter = new CursorPagerAdapter(this, GlideApp.with(this), getWindow(), data.first, data.second, leftIsRecent);
+    adapter = new CursorPagerAdapter(this, Glide.with(this), getWindow(), data.first, data.second, leftIsRecent);
     mediaPager.setAdapter(adapter);
 
     viewModel.setCursor(this, data.first, leftIsRecent);
@@ -588,7 +588,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
 
   private static class SingleItemPagerAdapter extends MediaItemAdapter {
 
-    private final GlideRequests glideRequests;
+    private final RequestManager glideRequests;
     private final Window        window;
     private final Uri           uri;
     private final String        mediaType;
@@ -596,7 +596,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
 
     private final LayoutInflater inflater;
 
-    SingleItemPagerAdapter(@NonNull Context context, @NonNull GlideRequests glideRequests,
+    SingleItemPagerAdapter(@NonNull Context context, @NonNull RequestManager glideRequests,
                            @NonNull Window window, @NonNull Uri uri, @NonNull String mediaType,
                            long size)
     {
@@ -663,14 +663,14 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     private final WeakHashMap<Integer, MediaView> mediaViews = new WeakHashMap<>();
 
     private final Context       context;
-    private final GlideRequests glideRequests;
+    private final RequestManager glideRequests;
     private final Window        window;
     private final Cursor        cursor;
     private final boolean       leftIsRecent;
 
     private int     autoPlayPosition;
 
-    CursorPagerAdapter(@NonNull Context context, @NonNull GlideRequests glideRequests,
+    CursorPagerAdapter(@NonNull Context context, @NonNull RequestManager glideRequests,
                        @NonNull Window window, @NonNull Cursor cursor, int autoPlayPosition,
                        boolean leftIsRecent)
     {

--- a/app/src/main/java/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/PassphraseRequiredActionBarActivity.java
@@ -34,7 +34,7 @@ public abstract class PassphraseRequiredActionBarActivity extends BaseActionBarA
   private BroadcastReceiver          clearKeyReceiver;
 
   @Override
-  protected final void onCreate(Bundle savedInstanceState) {
+  protected void onCreate(Bundle savedInstanceState) {
     Log.i(TAG, "onCreate(" + savedInstanceState + ")");
     onPreCreate();
 

--- a/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/calls/WebRtcCallActivity.kt
@@ -22,6 +22,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Job
@@ -38,7 +39,6 @@ import org.session.libsession.utilities.truncateIdForDisplay
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.PassphraseRequiredActionBarActivity
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
-import org.thoughtcrime.securesms.mms.GlideApp
 import org.thoughtcrime.securesms.permissions.Permissions
 import org.thoughtcrime.securesms.service.WebRtcCallService
 import org.thoughtcrime.securesms.util.AvatarPlaceholderGenerator
@@ -70,7 +70,7 @@ class WebRtcCallActivity : PassphraseRequiredActionBarActivity() {
     }
 
     private val viewModel by viewModels<CallViewModel>()
-    private val glide by lazy { GlideApp.with(this) }
+    private val glide by lazy { Glide.with(this) }
     private lateinit var binding: ActivityWebrtcBinding
     private var uiJob: Job? = null
     private var wantsToAnswer = false

--- a/app/src/main/java/org/thoughtcrime/securesms/components/AvatarImageView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/AvatarImageView.java
@@ -25,8 +25,8 @@ import org.session.libsession.utilities.Address;
 import org.session.libsession.utilities.ThemeUtil;
 import org.session.libsession.utilities.recipients.Recipient;
 import org.session.libsession.utilities.recipients.RecipientExporter;
-import org.thoughtcrime.securesms.mms.GlideApp;
-import org.thoughtcrime.securesms.mms.GlideRequests;
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.RequestManager;
 import org.thoughtcrime.securesms.util.AvatarPlaceholderGenerator;
 
 import java.util.Objects;
@@ -117,10 +117,10 @@ public class AvatarImageView extends AppCompatImageView {
   }
 
   private void updateAvatar(Recipient recipient) {
-    setAvatar(GlideApp.with(getContext()), recipient, false);
+    setAvatar(Glide.with(getContext()), recipient, false);
   }
 
-  public void setAvatar(@NonNull GlideRequests requestManager, @Nullable Recipient recipient, boolean quickContactEnabled) {
+  public void setAvatar(@NonNull RequestManager requestManager, @Nullable Recipient recipient, boolean quickContactEnabled) {
     if (recipient != null) {
       if (recipient.isLocalNumber()) {
         setImageDrawable(new ResourceContactPhoto(R.drawable.ic_note_to_self).asDrawable(getContext(), recipient.getColor().toAvatarColor(getContext()), inverted));
@@ -156,7 +156,7 @@ public class AvatarImageView extends AppCompatImageView {
     }
   }
 
-  public void clear(@NonNull GlideRequests glideRequests) {
+  public void clear(@NonNull RequestManager glideRequests) {
     glideRequests.clear(this);
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/components/MediaView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/MediaView.java
@@ -13,7 +13,7 @@ import android.view.Window;
 import android.widget.FrameLayout;
 
 import network.loki.messenger.R;
-import org.thoughtcrime.securesms.mms.GlideRequests;
+import com.bumptech.glide.RequestManager;
 import org.thoughtcrime.securesms.mms.VideoSlide;
 import org.thoughtcrime.securesms.video.VideoPlayer;
 
@@ -54,7 +54,7 @@ public class MediaView extends FrameLayout {
     this.videoView = new Stub<>(findViewById(R.id.video_player_stub));
   }
 
-  public void set(@NonNull GlideRequests glideRequests,
+  public void set(@NonNull RequestManager glideRequests,
                   @NonNull Window window,
                   @NonNull Uri source,
                   @NonNull String mediaType,

--- a/app/src/main/java/org/thoughtcrime/securesms/components/ProfilePictureView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ProfilePictureView.kt
@@ -20,8 +20,8 @@ import org.session.libsession.utilities.GroupUtil
 import org.session.libsession.utilities.recipients.Recipient
 import org.session.libsignal.utilities.Log
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
-import org.thoughtcrime.securesms.mms.GlideApp
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 
 class ProfilePictureView @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null
@@ -29,7 +29,7 @@ class ProfilePictureView @JvmOverloads constructor(
     private val TAG = "ProfilePictureView"
 
     private val binding = ViewProfilePictureBinding.inflate(LayoutInflater.from(context), this)
-    private val glide: GlideRequests = GlideApp.with(this)
+    private val glide: RequestManager = Glide.with(this)
     private val prefs = AppTextSecurePreferences(context)
     private val userPublicKey = prefs.getLocalNumber()
     var publicKey: String? = null

--- a/app/src/main/java/org/thoughtcrime/securesms/components/RecentPhotoViewRail.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/RecentPhotoViewRail.java
@@ -28,7 +28,7 @@ import com.bumptech.glide.signature.MediaStoreSignature;
 import network.loki.messenger.R;
 import org.thoughtcrime.securesms.database.CursorRecyclerViewAdapter;
 import org.thoughtcrime.securesms.database.loaders.RecentPhotosLoader;
-import org.thoughtcrime.securesms.mms.GlideApp;
+import com.bumptech.glide.Glide;
 
 import org.session.libsession.utilities.ViewUtil;
 
@@ -118,7 +118,7 @@ public class RecentPhotoViewRail extends FrameLayout implements LoaderManager.Lo
 
       Key signature = new MediaStoreSignature(mimeType, dateModified, orientation);
 
-      GlideApp.with(getContext().getApplicationContext())
+      Glide.with(getContext().getApplicationContext())
               .load(uri)
               .signature(signature)
               .diskCacheStrategy(DiskCacheStrategy.NONE)

--- a/app/src/main/java/org/thoughtcrime/securesms/components/StickerView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/StickerView.java
@@ -8,7 +8,7 @@ import android.view.View;
 import android.widget.FrameLayout;
 
 import org.thoughtcrime.securesms.conversation.v2.utilities.ThumbnailView;
-import org.thoughtcrime.securesms.mms.GlideRequests;
+import com.bumptech.glide.RequestManager;
 
 import org.thoughtcrime.securesms.mms.Slide;
 import org.thoughtcrime.securesms.mms.SlideClickListener;

--- a/app/src/main/java/org/thoughtcrime/securesms/components/ZoomingImageView.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/ZoomingImageView.java
@@ -25,7 +25,7 @@ import network.loki.messenger.R;
 import org.thoughtcrime.securesms.components.subsampling.AttachmentBitmapDecoder;
 import org.thoughtcrime.securesms.components.subsampling.AttachmentRegionDecoder;
 import org.thoughtcrime.securesms.mms.DecryptableStreamUriLoader.DecryptableUri;
-import org.thoughtcrime.securesms.mms.GlideRequests;
+import com.bumptech.glide.RequestManager;
 import org.thoughtcrime.securesms.mms.PartAuthority;
 import org.thoughtcrime.securesms.util.BitmapDecodingException;
 import org.thoughtcrime.securesms.util.BitmapUtil;
@@ -62,7 +62,7 @@ public class ZoomingImageView extends FrameLayout {
   }
 
   @SuppressLint("StaticFieldLeak")
-  public void setImageUri(@NonNull GlideRequests glideRequests, @NonNull Uri uri, @NonNull String contentType)
+  public void setImageUri(@NonNull RequestManager glideRequests, @NonNull Uri uri, @NonNull String contentType)
   {
     final Context context        = getContext();
     final int     maxTextureSize = BitmapUtil.getMaxTextureSize();
@@ -97,7 +97,7 @@ public class ZoomingImageView extends FrameLayout {
     }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
   }
 
-  private void setImageViewUri(@NonNull GlideRequests glideRequests, @NonNull Uri uri) {
+  private void setImageViewUri(@NonNull RequestManager glideRequests, @NonNull Uri uri) {
     photoView.setVisibility(View.VISIBLE);
     subsamplingImageView.setVisibility(View.GONE);
 

--- a/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiKeyboardProvider.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiKeyboardProvider.java
@@ -12,7 +12,7 @@ import android.widget.ImageView;
 
 
 import org.thoughtcrime.securesms.components.emoji.EmojiPageViewGridAdapter.VariationSelectorListener;
-import org.thoughtcrime.securesms.mms.GlideRequests;
+import com.bumptech.glide.RequestManager;
 import org.thoughtcrime.securesms.util.ResUtil;
 
 import org.session.libsession.utilities.ThemeUtil;
@@ -87,7 +87,7 @@ public class EmojiKeyboardProvider implements MediaKeyboardProvider,
   }
 
   @Override
-  public void loadCategoryTabIcon(@NonNull GlideRequests glideRequests, @NonNull ImageView imageView, int index) {
+  public void loadCategoryTabIcon(@NonNull RequestManager glideRequests, @NonNull ImageView imageView, int index) {
     Drawable drawable = ResUtil.getDrawable(context, models.get(index).getIconAttr());
     imageView.setImageDrawable(drawable);
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/components/emoji/MediaKeyboard.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/emoji/MediaKeyboard.java
@@ -17,7 +17,7 @@ import android.widget.FrameLayout;
 import org.thoughtcrime.securesms.components.InputAwareLayout.InputView;
 import org.thoughtcrime.securesms.components.RepeatableImageKey;
 import org.session.libsignal.utilities.Log;
-import org.thoughtcrime.securesms.mms.GlideApp;
+import com.bumptech.glide.Glide;
 
 import java.util.Arrays;
 
@@ -158,7 +158,7 @@ public class MediaKeyboard extends FrameLayout implements InputView,
     this.searchButton          = view.findViewById(R.id.media_keyboard_search);
     this.addButton             = view.findViewById(R.id.media_keyboard_add);
 
-    this.categoryTabAdapter = new MediaKeyboardBottomTabAdapter(GlideApp.with(this), this);
+    this.categoryTabAdapter = new MediaKeyboardBottomTabAdapter(Glide.with(this), this);
 
     categoryTabs.setLayoutManager(new LinearLayoutManager(getContext(), LinearLayoutManager.HORIZONTAL, false));
     categoryTabs.setAdapter(categoryTabAdapter);

--- a/app/src/main/java/org/thoughtcrime/securesms/components/emoji/MediaKeyboardBottomTabAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/emoji/MediaKeyboardBottomTabAdapter.java
@@ -9,20 +9,20 @@ import android.widget.ImageView;
 
 
 import org.thoughtcrime.securesms.components.emoji.MediaKeyboardProvider.TabIconProvider;
-import org.thoughtcrime.securesms.mms.GlideRequests;
+import com.bumptech.glide.RequestManager;
 
 import network.loki.messenger.R;
 
 public class MediaKeyboardBottomTabAdapter extends RecyclerView.Adapter<MediaKeyboardBottomTabAdapter.MediaKeyboardBottomTabViewHolder>  {
 
-  private final GlideRequests glideRequests;
+  private final RequestManager glideRequests;
   private final EventListener eventListener;
 
   private TabIconProvider tabIconProvider;
   private int             activePosition;
   private int             count;
 
-  public MediaKeyboardBottomTabAdapter(@NonNull GlideRequests glideRequests, @NonNull EventListener eventListener) {
+  public MediaKeyboardBottomTabAdapter(@NonNull RequestManager glideRequests, @NonNull EventListener eventListener) {
     this.glideRequests = glideRequests;
     this.eventListener = eventListener;
   }
@@ -71,7 +71,7 @@ public class MediaKeyboardBottomTabAdapter extends RecyclerView.Adapter<MediaKey
       this.indicator = itemView.findViewById(R.id.media_keyboard_bottom_tab_indicator);
     }
 
-    void bind(@NonNull GlideRequests glideRequests,
+    void bind(@NonNull RequestManager glideRequests,
               @NonNull EventListener eventListener,
               @NonNull TabIconProvider tabIconProvider,
               int index,

--- a/app/src/main/java/org/thoughtcrime/securesms/components/emoji/MediaKeyboardProvider.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/emoji/MediaKeyboardProvider.java
@@ -8,7 +8,7 @@ import android.widget.ImageView;
 
 
 
-import org.thoughtcrime.securesms.mms.GlideRequests;
+import com.bumptech.glide.RequestManager;
 
 public interface MediaKeyboardProvider {
   @LayoutRes int getProviderIconView(boolean selected);
@@ -48,6 +48,6 @@ public interface MediaKeyboardProvider {
   }
 
   interface TabIconProvider {
-    void loadCategoryTabIcon(@NonNull GlideRequests glideRequests, @NonNull ImageView imageView, int index);
+    void loadCategoryTabIcon(@NonNull RequestManager glideRequests, @NonNull ImageView imageView, int index);
   }
 }

--- a/app/src/main/java/org/thoughtcrime/securesms/contacts/ContactSelectionListAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/contacts/ContactSelectionListAdapter.kt
@@ -6,10 +6,10 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import network.loki.messenger.databinding.ContactSelectionListDividerBinding
 import org.session.libsession.utilities.recipients.Recipient
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.RequestManager
 
 class ContactSelectionListAdapter(private val context: Context, private val multiSelect: Boolean) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
-    lateinit var glide: GlideRequests
+    lateinit var glide: RequestManager
     val selectedContacts = mutableSetOf<Recipient>()
     var items = listOf<ContactSelectionListItem>()
         set(value) { field = value; notifyDataSetChanged() }

--- a/app/src/main/java/org/thoughtcrime/securesms/contacts/ContactSelectionListFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/contacts/ContactSelectionListFragment.kt
@@ -11,7 +11,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import network.loki.messenger.databinding.ContactSelectionListFragmentBinding
 import org.session.libsession.utilities.recipients.Recipient
 import org.session.libsignal.utilities.Log
-import org.thoughtcrime.securesms.mms.GlideApp
+import com.bumptech.glide.Glide
 
 class ContactSelectionListFragment : Fragment(), LoaderManager.LoaderCallbacks<List<ContactSelectionListItem>>, ContactClickListener {
     private lateinit var binding: ContactSelectionListFragmentBinding
@@ -27,7 +27,7 @@ class ContactSelectionListFragment : Fragment(), LoaderManager.LoaderCallbacks<L
 
     private val listAdapter by lazy {
         val result = ContactSelectionListAdapter(requireActivity(), multiSelect)
-        result.glide = GlideApp.with(this)
+        result.glide = Glide.with(this)
         result.contactClickListener = this
         result
     }

--- a/app/src/main/java/org/thoughtcrime/securesms/contacts/SelectContactsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/contacts/SelectContactsActivity.kt
@@ -12,7 +12,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import network.loki.messenger.R
 import network.loki.messenger.databinding.ActivitySelectContactsBinding
 import org.thoughtcrime.securesms.PassphraseRequiredActionBarActivity
-import org.thoughtcrime.securesms.mms.GlideApp
+import com.bumptech.glide.Glide
 
 class SelectContactsActivity : PassphraseRequiredActionBarActivity(), LoaderManager.LoaderCallbacks<List<String>> {
     private lateinit var binding: ActivitySelectContactsBinding
@@ -21,7 +21,7 @@ class SelectContactsActivity : PassphraseRequiredActionBarActivity(), LoaderMana
     private lateinit var usersToExclude: Set<String>
 
     private val selectContactsAdapter by lazy {
-        SelectContactsAdapter(this, GlideApp.with(this))
+        SelectContactsAdapter(this, Glide.with(this))
     }
 
     companion object {

--- a/app/src/main/java/org/thoughtcrime/securesms/contacts/SelectContactsAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/contacts/SelectContactsAdapter.kt
@@ -4,10 +4,10 @@ import android.content.Context
 import androidx.recyclerview.widget.RecyclerView
 import android.view.ViewGroup
 import org.session.libsession.utilities.Address
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.RequestManager
 import org.session.libsession.utilities.recipients.Recipient
 
-class SelectContactsAdapter(private val context: Context, private val glide: GlideRequests) : RecyclerView.Adapter<SelectContactsAdapter.ViewHolder>() {
+class SelectContactsAdapter(private val context: Context, private val glide: RequestManager) : RecyclerView.Adapter<SelectContactsAdapter.ViewHolder>() {
     val selectedMembers = mutableSetOf<String>()
     var members = listOf<String>()
         set(value) { field = value; notifyDataSetChanged() }

--- a/app/src/main/java/org/thoughtcrime/securesms/contacts/UserView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/contacts/UserView.kt
@@ -10,7 +10,7 @@ import network.loki.messenger.databinding.ViewUserBinding
 import org.session.libsession.messaging.contacts.Contact
 import org.session.libsession.utilities.recipients.Recipient
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.RequestManager
 
 class UserView : LinearLayout {
     private lateinit var binding: ViewUserBinding
@@ -45,7 +45,7 @@ class UserView : LinearLayout {
     // endregion
 
     // region Updating
-    fun bind(user: Recipient, glide: GlideRequests, actionIndicator: ActionIndicator, isSelected: Boolean = false) {
+    fun bind(user: Recipient, glide: RequestManager, actionIndicator: ActionIndicator, isSelected: Boolean = false) {
         val isLocalUser = user.isLocalNumber
         fun getUserDisplayName(publicKey: String): String {
             if (isLocalUser) return context.getString(R.string.MessageRecord_you)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -156,7 +156,7 @@ import org.thoughtcrime.securesms.mediasend.Media
 import org.thoughtcrime.securesms.mediasend.MediaSendActivity
 import org.thoughtcrime.securesms.mms.AudioSlide
 import org.thoughtcrime.securesms.mms.GifSlide
-import org.thoughtcrime.securesms.mms.GlideApp
+import com.bumptech.glide.Glide
 import org.thoughtcrime.securesms.mms.ImageSlide
 import org.thoughtcrime.securesms.mms.MediaConstraints
 import org.thoughtcrime.securesms.mms.Slide
@@ -349,7 +349,7 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
         adapter
     }
 
-    private val glide by lazy { GlideApp.with(this) }
+    private val glide by lazy { Glide.with(this) }
     private val lockViewHitMargin by lazy { toPx(40, resources) }
     private val gifButton by lazy { InputBarButton(this, R.drawable.ic_gif_white_24dp, hasOpaqueBackground = true, isGIFButton = true) }
     private val documentButton by lazy { InputBarButton(this, R.drawable.ic_document_small_dark, hasOpaqueBackground = true) }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationAdapter.kt
@@ -26,7 +26,7 @@ import org.thoughtcrime.securesms.conversation.v2.messages.VisibleMessageViewDel
 import org.thoughtcrime.securesms.database.CursorRecyclerViewAdapter
 import org.thoughtcrime.securesms.database.model.MessageRecord
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.RequestManager
 import org.thoughtcrime.securesms.preferences.PrivacySettingsActivity
 import org.thoughtcrime.securesms.showSessionDialog
 import java.util.concurrent.atomic.AtomicLong
@@ -42,7 +42,7 @@ class ConversationAdapter(
     private val onItemLongPress: (MessageRecord, Int, VisibleMessageView) -> Unit,
     private val onDeselect: (MessageRecord, Int) -> Unit,
     private val onAttachmentNeedsDownload: (DatabaseAttachment) -> Unit,
-    private val glide: GlideRequests,
+    private val glide: RequestManager,
     lifecycleCoroutineScope: LifecycleCoroutineScope
 ) : CursorRecyclerViewAdapter<ViewHolder>(context, cursor) {
     private val messageDB by lazy { DatabaseComponent.get(context).mmsSmsDatabase() }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/components/AlbumThumbnailView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/components/AlbumThumbnailView.kt
@@ -20,7 +20,7 @@ import org.thoughtcrime.securesms.MediaPreviewActivity
 import org.thoughtcrime.securesms.components.CornerMask
 import org.thoughtcrime.securesms.conversation.v2.utilities.ThumbnailView
 import org.thoughtcrime.securesms.database.model.MmsMessageRecord
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.RequestManager
 import org.thoughtcrime.securesms.mms.Slide
 import org.thoughtcrime.securesms.util.ActivityDispatcher
 
@@ -80,7 +80,7 @@ class AlbumThumbnailView : RelativeLayout {
         slideSize = -1
     }
 
-    fun bind(glideRequests: GlideRequests, message: MmsMessageRecord,
+    fun bind(glideRequests: RequestManager, message: MmsMessageRecord,
              isStart: Boolean, isEnd: Boolean) {
         slides = message.slideDeck.thumbnailSlides
         if (slides.isEmpty()) {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/components/LinkPreviewDraftView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/components/LinkPreviewDraftView.kt
@@ -7,7 +7,7 @@ import android.widget.LinearLayout
 import androidx.core.view.isVisible
 import network.loki.messenger.databinding.ViewLinkPreviewDraftBinding
 import org.session.libsession.messaging.sending_receiving.link_preview.LinkPreview
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.RequestManager
 import org.thoughtcrime.securesms.mms.ImageSlide
 import org.thoughtcrime.securesms.util.toPx
 
@@ -27,7 +27,7 @@ class LinkPreviewDraftView : LinearLayout {
         binding.linkPreviewDraftCancelButton.setOnClickListener { cancel() }
     }
 
-    fun update(glide: GlideRequests, linkPreview: LinkPreview) {
+    fun update(glide: RequestManager, linkPreview: LinkPreview) {
         // Hide the loader and show the content view
         binding.linkPreviewDraftContainer.isVisible = true
         binding.linkPreviewDraftLoader.isVisible = false

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/components/MentionCandidateSelectionView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/components/MentionCandidateSelectionView.kt
@@ -9,13 +9,13 @@ import android.widget.BaseAdapter
 import android.widget.ListView
 import org.session.libsession.messaging.mentions.Mention
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.RequestManager
 import org.thoughtcrime.securesms.util.toPx
 
 class MentionCandidateSelectionView(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : ListView(context, attrs, defStyleAttr) {
     private var mentionCandidates = listOf<Mention>()
         set(newValue) { field = newValue; mentionCandidateSelectionViewAdapter.mentionCandidates = newValue }
-    var glide: GlideRequests? = null
+    var glide: RequestManager? = null
         set(newValue) { field = newValue; mentionCandidateSelectionViewAdapter.glide = newValue }
     var openGroupServer: String? = null
         set(newValue) { field = newValue; mentionCandidateSelectionViewAdapter.openGroupServer = openGroupServer }
@@ -28,7 +28,7 @@ class MentionCandidateSelectionView(context: Context, attrs: AttributeSet?, defS
     private class Adapter(private val context: Context) : BaseAdapter() {
         var mentionCandidates = listOf<Mention>()
             set(newValue) { field = newValue; notifyDataSetChanged() }
-        var glide: GlideRequests? = null
+        var glide: RequestManager? = null
         var openGroupServer: String? = null
         var openGroupRoom: String? = null
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/components/MentionCandidateView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/components/MentionCandidateView.kt
@@ -8,13 +8,13 @@ import android.widget.LinearLayout
 import network.loki.messenger.databinding.ViewMentionCandidateBinding
 import org.session.libsession.messaging.mentions.Mention
 import org.thoughtcrime.securesms.groups.OpenGroupManager
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.RequestManager
 
 class MentionCandidateView : LinearLayout {
     private lateinit var binding: ViewMentionCandidateBinding
     var mentionCandidate = Mention("", "")
         set(newValue) { field = newValue; update() }
-    var glide: GlideRequests? = null
+    var glide: RequestManager? = null
     var openGroupServer: String? = null
     var openGroupRoom: String? = null
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/input_bar/InputBar.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/input_bar/InputBar.kt
@@ -27,7 +27,7 @@ import org.thoughtcrime.securesms.conversation.v2.messages.QuoteView
 import org.thoughtcrime.securesms.conversation.v2.messages.QuoteViewDelegate
 import org.thoughtcrime.securesms.database.model.MessageRecord
 import org.thoughtcrime.securesms.database.model.MmsMessageRecord
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.RequestManager
 import org.thoughtcrime.securesms.util.addTextChangedListener
 import org.thoughtcrime.securesms.util.contains
 
@@ -188,7 +188,7 @@ class InputBar @JvmOverloads constructor(
 
     private fun startRecordingVoiceMessage() { delegate?.startRecordingVoiceMessage() }
 
-    fun draftQuote(thread: Recipient, message: MessageRecord, glide: GlideRequests) {
+    fun draftQuote(thread: Recipient, message: MessageRecord, glide: RequestManager) {
         quoteView?.let(binding.inputBarAdditionalContentContainer::removeView)
 
         quote = message
@@ -238,7 +238,7 @@ class InputBar @JvmOverloads constructor(
         requestLayout()
     }
 
-    fun updateLinkPreviewDraft(glide: GlideRequests, updatedLinkPreview: LinkPreview) {
+    fun updateLinkPreviewDraft(glide: RequestManager, updatedLinkPreview: LinkPreview) {
         // Update our `linkPreview` property with the new (provided as an argument to this function)
         // then update the View from that.
         linkPreview = updatedLinkPreview.also { linkPreviewDraftView?.update(glide, it) }

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/LinkPreviewView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/LinkPreviewView.kt
@@ -15,7 +15,7 @@ import org.thoughtcrime.securesms.components.CornerMask
 import org.thoughtcrime.securesms.conversation.v2.ModalUrlBottomSheet
 import org.thoughtcrime.securesms.conversation.v2.utilities.MessageBubbleUtilities
 import org.thoughtcrime.securesms.database.model.MmsMessageRecord
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.RequestManager
 import org.thoughtcrime.securesms.mms.ImageSlide
 
 class LinkPreviewView : LinearLayout {
@@ -32,7 +32,7 @@ class LinkPreviewView : LinearLayout {
     // region Updating
     fun bind(
         message: MmsMessageRecord,
-        glide: GlideRequests,
+        glide: RequestManager,
         isStartOfMessageCluster: Boolean,
         isEndOfMessageCluster: Boolean
     ) {

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/QuoteView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/QuoteView.kt
@@ -18,7 +18,7 @@ import org.session.libsession.utilities.getColorFromAttr
 import org.session.libsession.utilities.recipients.Recipient
 import org.thoughtcrime.securesms.conversation.v2.utilities.MentionUtilities
 import org.thoughtcrime.securesms.database.SessionContactDatabase
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.RequestManager
 import org.thoughtcrime.securesms.mms.SlideDeck
 import org.thoughtcrime.securesms.util.MediaUtil
 import org.thoughtcrime.securesms.util.getAccentColor
@@ -68,7 +68,7 @@ class QuoteView @JvmOverloads constructor(context: Context, attrs: AttributeSet?
     // region Updating
     fun bind(authorPublicKey: String, body: String?, attachments: SlideDeck?, thread: Recipient,
         isOutgoingMessage: Boolean, isOpenGroupInvitation: Boolean, threadID: Long,
-        isOriginalMissing: Boolean, glide: GlideRequests) {
+        isOriginalMissing: Boolean, glide: RequestManager) {
         // Author
         val author = contactDb.getContactWithAccountID(authorPublicKey)
         val localNumber = TextSecurePreferences.getLocalNumber(context)

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageContentView.kt
@@ -38,8 +38,8 @@ import org.thoughtcrime.securesms.conversation.v2.utilities.TextUtilities.getInt
 import org.thoughtcrime.securesms.database.model.MessageRecord
 import org.thoughtcrime.securesms.database.model.MmsMessageRecord
 import org.thoughtcrime.securesms.database.model.SmsMessageRecord
-import org.thoughtcrime.securesms.mms.GlideApp
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import org.thoughtcrime.securesms.util.GlowViewUtilities
 import org.thoughtcrime.securesms.util.SearchUtil
 import org.thoughtcrime.securesms.util.getAccentColor
@@ -63,7 +63,7 @@ class VisibleMessageContentView : ConstraintLayout {
         message: MessageRecord,
         isStartOfMessageCluster: Boolean = true,
         isEndOfMessageCluster: Boolean = true,
-        glide: GlideRequests = GlideApp.with(this),
+        glide: RequestManager = Glide.with(this),
         thread: Recipient,
         searchQuery: String? = null,
         contactIsTrusted: Boolean = true,

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/messages/VisibleMessageView.kt
@@ -52,8 +52,8 @@ import org.thoughtcrime.securesms.database.ThreadDatabase
 import org.thoughtcrime.securesms.database.model.MessageRecord
 import org.thoughtcrime.securesms.groups.OpenGroupManager
 import org.thoughtcrime.securesms.home.UserDetailsBottomSheet
-import org.thoughtcrime.securesms.mms.GlideApp
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import org.thoughtcrime.securesms.util.DateUtils
 import org.thoughtcrime.securesms.util.disableClipping
 import org.thoughtcrime.securesms.util.toDp
@@ -141,7 +141,7 @@ class VisibleMessageView : FrameLayout {
         message: MessageRecord,
         previous: MessageRecord? = null,
         next: MessageRecord? = null,
-        glide: GlideRequests = GlideApp.with(this),
+        glide: RequestManager = Glide.with(this),
         searchQuery: String? = null,
         contact: Contact? = null,
         senderAccountID: String,

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/utilities/AttachmentManager.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/utilities/AttachmentManager.java
@@ -44,7 +44,7 @@ import org.thoughtcrime.securesms.mediasend.MediaSendActivity;
 import org.thoughtcrime.securesms.mms.AudioSlide;
 import org.thoughtcrime.securesms.mms.DocumentSlide;
 import org.thoughtcrime.securesms.mms.GifSlide;
-import org.thoughtcrime.securesms.mms.GlideRequests;
+import com.bumptech.glide.RequestManager;
 import org.thoughtcrime.securesms.mms.ImageSlide;
 import org.thoughtcrime.securesms.mms.MediaConstraints;
 import org.thoughtcrime.securesms.mms.PartAuthority;
@@ -126,7 +126,7 @@ public class AttachmentManager {
   }
 
   @SuppressLint("StaticFieldLeak")
-  public ListenableFuture<Boolean> setMedia(@NonNull final GlideRequests glideRequests,
+  public ListenableFuture<Boolean> setMedia(@NonNull final RequestManager glideRequests,
                                             @NonNull final Uri uri,
                                             @NonNull final MediaType mediaType,
                                             @NonNull final MediaConstraints constraints,

--- a/app/src/main/java/org/thoughtcrime/securesms/giph/ui/GiphyAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/giph/ui/GiphyAdapter.java
@@ -29,8 +29,8 @@ import org.session.libsession.utilities.ViewUtil;
 import org.session.libsignal.utilities.Log;
 import org.thoughtcrime.securesms.giph.model.ChunkedImageUrl;
 import org.thoughtcrime.securesms.giph.model.GiphyImage;
-import org.thoughtcrime.securesms.mms.GlideApp;
-import org.thoughtcrime.securesms.mms.GlideRequests;
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.RequestManager;
 
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -43,7 +43,7 @@ class GiphyAdapter extends RecyclerView.Adapter<GiphyAdapter.GiphyViewHolder> {
   private static final String TAG = GiphyAdapter.class.getSimpleName();
 
   private final Context       context;
-  private final GlideRequests glideRequests;
+  private final RequestManager glideRequests;
 
   private List<GiphyImage>     images;
   private OnItemClickListener  listener;
@@ -117,7 +117,7 @@ class GiphyAdapter extends RecyclerView.Adapter<GiphyAdapter.GiphyViewHolder> {
     }
   }
 
-  GiphyAdapter(@NonNull Context context, @NonNull GlideRequests glideRequests, @NonNull List<GiphyImage> images) {
+  GiphyAdapter(@NonNull Context context, @NonNull RequestManager glideRequests, @NonNull List<GiphyImage> images) {
     this.context       = context.getApplicationContext();
     this.glideRequests = glideRequests;
     this.images        = images;
@@ -150,7 +150,7 @@ class GiphyAdapter extends RecyclerView.Adapter<GiphyAdapter.GiphyViewHolder> {
     holder.thumbnail.setAspectRatio(image.getGifAspectRatio());
     holder.gifProgress.setVisibility(View.GONE);
 
-    RequestBuilder<Drawable> thumbnailRequest = GlideApp.with(context)
+    RequestBuilder<Drawable> thumbnailRequest = Glide.with(context)
                                                         .load(new ChunkedImageUrl(image.getStillUrl(), image.getStillSize()))
                                                         .diskCacheStrategy(DiskCacheStrategy.NONE);
 

--- a/app/src/main/java/org/thoughtcrime/securesms/giph/ui/GiphyFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/giph/ui/GiphyFragment.java
@@ -19,7 +19,7 @@ import android.widget.TextView;
 import org.thoughtcrime.securesms.giph.model.GiphyImage;
 import org.thoughtcrime.securesms.giph.net.GiphyLoader;
 import org.thoughtcrime.securesms.giph.util.InfiniteScrollListener;
-import org.thoughtcrime.securesms.mms.GlideApp;
+import com.bumptech.glide.Glide;
 import org.session.libsession.utilities.TextSecurePreferences;
 import org.session.libsession.utilities.ViewUtil;
 
@@ -54,7 +54,7 @@ public abstract class GiphyFragment extends Fragment implements LoaderManager.Lo
   public void onActivityCreated(Bundle bundle) {
     super.onActivityCreated(bundle);
 
-    this.giphyAdapter = new GiphyAdapter(getActivity(), GlideApp.with(this), new LinkedList<>());
+    this.giphyAdapter = new GiphyAdapter(getActivity(), Glide.with(this), new LinkedList<>());
     this.giphyAdapter.setListener(this);
 
     setLayoutManager(TextSecurePreferences.isGifSearchInGridLayout(getContext()));

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/CreateGroupFragment.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/CreateGroupFragment.kt
@@ -29,7 +29,7 @@ import org.thoughtcrime.securesms.conversation.start.StartConversationDelegate
 import org.thoughtcrime.securesms.conversation.v2.ConversationActivityV2
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
 import org.thoughtcrime.securesms.keyboard.emoji.KeyboardPageSearchView
-import org.thoughtcrime.securesms.mms.GlideApp
+import com.bumptech.glide.Glide
 import org.thoughtcrime.securesms.util.fadeIn
 import org.thoughtcrime.securesms.util.fadeOut
 import javax.inject.Inject
@@ -55,7 +55,7 @@ class CreateGroupFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val adapter = SelectContactsAdapter(requireContext(), GlideApp.with(requireContext()))
+        val adapter = SelectContactsAdapter(requireContext(), Glide.with(requireContext()))
         binding.backButton.setOnClickListener { delegate.onDialogBackPressed() }
         binding.closeButton.setOnClickListener { delegate.onDialogClosePressed() }
         binding.contactSearch.callbacks = object : KeyboardPageSearchView.Callbacks {

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/EditClosedGroupActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/EditClosedGroupActivity.kt
@@ -37,7 +37,7 @@ import org.thoughtcrime.securesms.database.Storage
 import org.thoughtcrime.securesms.dependencies.ConfigFactory
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
 import org.thoughtcrime.securesms.groups.ClosedGroupManager.updateLegacyGroup
-import org.thoughtcrime.securesms.mms.GlideApp
+import com.bumptech.glide.Glide
 import org.thoughtcrime.securesms.util.fadeIn
 import org.thoughtcrime.securesms.util.fadeOut
 import java.io.IOException
@@ -76,9 +76,9 @@ class EditClosedGroupActivity : PassphraseRequiredActionBarActivity() {
 
     private val memberListAdapter by lazy {
         if (isSelfAdmin)
-            EditClosedGroupMembersAdapter(this, GlideApp.with(this), isSelfAdmin, this::onMemberClick)
+            EditClosedGroupMembersAdapter(this, Glide.with(this), isSelfAdmin, this::onMemberClick)
         else
-            EditClosedGroupMembersAdapter(this, GlideApp.with(this), isSelfAdmin)
+            EditClosedGroupMembersAdapter(this, Glide.with(this), isSelfAdmin)
     }
 
     private lateinit var mainContentContainer: LinearLayout

--- a/app/src/main/java/org/thoughtcrime/securesms/groups/EditClosedGroupMembersAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/groups/EditClosedGroupMembersAdapter.kt
@@ -5,13 +5,13 @@ import androidx.recyclerview.widget.RecyclerView
 import android.view.ViewGroup
 import org.session.libsession.utilities.Address
 import org.thoughtcrime.securesms.contacts.UserView
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.RequestManager
 import org.session.libsession.utilities.recipients.Recipient
 import org.session.libsession.utilities.TextSecurePreferences
 
 class EditClosedGroupMembersAdapter(
     private val context: Context,
-    private val glide: GlideRequests,
+    private val glide: RequestManager,
     private val admin: Boolean,
     private val memberClickListener: ((String) -> Unit)? = null
 ) : RecyclerView.Adapter<EditClosedGroupMembersAdapter.ViewHolder>() {

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
@@ -62,8 +62,8 @@ import org.thoughtcrime.securesms.home.search.GlobalSearchInputLayout
 import org.thoughtcrime.securesms.home.search.GlobalSearchResult
 import org.thoughtcrime.securesms.home.search.GlobalSearchViewModel
 import org.thoughtcrime.securesms.messagerequests.MessageRequestsActivity
-import org.thoughtcrime.securesms.mms.GlideApp
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import org.thoughtcrime.securesms.notifications.PushRegistry
 import org.thoughtcrime.securesms.permissions.Permissions
 import org.thoughtcrime.securesms.preferences.SettingsActivity
@@ -91,7 +91,7 @@ class HomeActivity : PassphraseRequiredActionBarActivity(),
     }
 
     private lateinit var binding: ActivityHomeBinding
-    private lateinit var glide: GlideRequests
+    private lateinit var glide: RequestManager
 
     @Inject lateinit var threadDb: ThreadDatabase
     @Inject lateinit var mmsSmsDatabase: MmsSmsDatabase
@@ -151,7 +151,7 @@ class HomeActivity : PassphraseRequiredActionBarActivity(),
         // Set custom toolbar
         setSupportActionBar(binding.toolbar)
         // Set up Glide
-        glide = GlideApp.with(this)
+        glide = Glide.with(this)
         // Set up toolbar buttons
         binding.profileButton.setOnClickListener { openSettings() }
         binding.searchViewContainer.setOnClickListener {

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeAdapter.kt
@@ -7,10 +7,10 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListUpdateCallback
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.NO_ID
+import com.bumptech.glide.RequestManager
 import network.loki.messenger.R
 import network.loki.messenger.databinding.ViewMessageRequestBannerBinding
 import org.thoughtcrime.securesms.dependencies.ConfigFactory
-import org.thoughtcrime.securesms.mms.GlideRequests
 
 class HomeAdapter(
     private val context: Context,
@@ -74,7 +74,7 @@ class HomeAdapter(
         return data.threads[offsetPosition].threadId
     }
 
-    lateinit var glide: GlideRequests
+    lateinit var glide: RequestManager
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder =
         when (viewType) {

--- a/app/src/main/java/org/thoughtcrime/securesms/mediapreview/MediaRailAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediapreview/MediaRailAdapter.java
@@ -14,7 +14,7 @@ import network.loki.messenger.R;
 
 import org.thoughtcrime.securesms.conversation.v2.utilities.ThumbnailView;
 import org.thoughtcrime.securesms.mediasend.Media;
-import org.thoughtcrime.securesms.mms.GlideRequests;
+import com.bumptech.glide.RequestManager;
 import org.thoughtcrime.securesms.util.StableIdGenerator;
 
 import java.util.ArrayList;
@@ -25,7 +25,7 @@ public class MediaRailAdapter extends RecyclerView.Adapter<MediaRailAdapter.Medi
   private static final int TYPE_MEDIA  = 1;
   private static final int TYPE_BUTTON = 2;
 
-  private final GlideRequests glideRequests;
+  private final RequestManager glideRequests;
   private final List<Media>              media;
   private final RailItemListener         listener;
   private final boolean                  editable;
@@ -34,7 +34,7 @@ public class MediaRailAdapter extends RecyclerView.Adapter<MediaRailAdapter.Medi
   private RailItemAddListener addListener;
   private int activePosition;
 
-  public MediaRailAdapter(@NonNull GlideRequests glideRequests, @NonNull RailItemListener listener, boolean editable) {
+  public MediaRailAdapter(@NonNull RequestManager glideRequests, @NonNull RailItemListener listener, boolean editable) {
     this.glideRequests     = glideRequests;
     this.media             = new ArrayList<>();
     this.listener          = listener;
@@ -148,7 +148,7 @@ public class MediaRailAdapter extends RecyclerView.Adapter<MediaRailAdapter.Medi
       captionIndicator = itemView.findViewById(R.id.rail_item_caption);
     }
 
-    void bind(@NonNull Media media, boolean isActive, @NonNull GlideRequests glideRequests,
+    void bind(@NonNull Media media, boolean isActive, @NonNull RequestManager glideRequests,
               @NonNull RailItemListener railItemListener, int distanceFromActive, boolean editable)
     {
       image.setImageResource(glideRequests, media.getUri());

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/Camera1Fragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/Camera1Fragment.java
@@ -36,7 +36,7 @@ import com.bumptech.glide.request.transition.Transition;
 
 import network.loki.messenger.R;
 import org.session.libsignal.utilities.Log;
-import org.thoughtcrime.securesms.mms.GlideApp;
+import com.bumptech.glide.Glide;
 import org.session.libsession.utilities.ServiceUtil;
 import org.thoughtcrime.securesms.util.Stopwatch;
 import org.session.libsession.utilities.TextSecurePreferences;
@@ -236,7 +236,7 @@ public class Camera1Fragment extends Fragment implements TextureView.SurfaceText
       Transformation<Bitmap> transformation = frontFacing ? new MultiTransformation<>(new CenterCrop(), new FlipTransformation())
                                                           : new CenterCrop();
 
-      GlideApp.with(this)
+      Glide.with(this)
               .asBitmap()
               .load(jpegData)
               .transform(transformation)

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaPickerFolderAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaPickerFolderAdapter.java
@@ -14,18 +14,18 @@ import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
 
 
 import network.loki.messenger.R;
-import org.thoughtcrime.securesms.mms.GlideRequests;
+import com.bumptech.glide.RequestManager;
 
 import java.util.ArrayList;
 import java.util.List;
 
 class MediaPickerFolderAdapter extends RecyclerView.Adapter<MediaPickerFolderAdapter.FolderViewHolder> {
 
-  private final GlideRequests glideRequests;
+  private final RequestManager glideRequests;
   private final EventListener     eventListener;
   private final List<MediaFolder> folders;
 
-  MediaPickerFolderAdapter(@NonNull GlideRequests glideRequests, @NonNull EventListener eventListener) {
+  MediaPickerFolderAdapter(@NonNull RequestManager glideRequests, @NonNull EventListener eventListener) {
     this.glideRequests = glideRequests;
     this.eventListener = eventListener;
     this.folders       = new ArrayList<>();
@@ -74,7 +74,7 @@ class MediaPickerFolderAdapter extends RecyclerView.Adapter<MediaPickerFolderAda
       count     = itemView.findViewById(R.id.mediapicker_folder_item_count);
     }
 
-    void bind(@NonNull MediaFolder folder, @NonNull GlideRequests glideRequests, @NonNull EventListener eventListener) {
+    void bind(@NonNull MediaFolder folder, @NonNull RequestManager glideRequests, @NonNull EventListener eventListener) {
       title.setText(folder.getTitle());
       count.setText(String.valueOf(folder.getItemCount()));
 

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaPickerFolderFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaPickerFolderFragment.java
@@ -19,7 +19,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.WindowManager;
 
-import org.thoughtcrime.securesms.mms.GlideApp;
+import com.bumptech.glide.Glide;
 import org.session.libsession.utilities.recipients.Recipient;
 import org.session.libsignal.utilities.guava.Optional;
 
@@ -79,7 +79,7 @@ public class MediaPickerFolderFragment extends Fragment implements MediaPickerFo
     super.onViewCreated(view, savedInstanceState);
 
     RecyclerView             list    = view.findViewById(R.id.mediapicker_folder_list);
-    MediaPickerFolderAdapter adapter = new MediaPickerFolderAdapter(GlideApp.with(this), this);
+    MediaPickerFolderAdapter adapter = new MediaPickerFolderAdapter(Glide.with(this), this);
 
     layoutManager = new GridLayoutManager(requireContext(), 2);
     onScreenWidthChanged(getScreenWidth());

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaPickerItemAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaPickerItemAdapter.java
@@ -12,7 +12,7 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions;
 
 import network.loki.messenger.R;
-import org.thoughtcrime.securesms.mms.GlideRequests;
+import com.bumptech.glide.RequestManager;
 
 import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.StableIdGenerator;
@@ -24,7 +24,7 @@ import java.util.List;
 
 public class MediaPickerItemAdapter extends RecyclerView.Adapter<MediaPickerItemAdapter.ItemViewHolder> {
 
-  private final GlideRequests glideRequests;
+  private final RequestManager glideRequests;
   private final EventListener            eventListener;
   private final List<Media>              media;
   private final List<Media>              selected;
@@ -33,7 +33,7 @@ public class MediaPickerItemAdapter extends RecyclerView.Adapter<MediaPickerItem
 
   private boolean forcedMultiSelect;
 
-  public MediaPickerItemAdapter(@NonNull GlideRequests glideRequests, @NonNull EventListener eventListener, int maxSelection) {
+  public MediaPickerItemAdapter(@NonNull RequestManager glideRequests, @NonNull EventListener eventListener, int maxSelection) {
     this.glideRequests     = glideRequests;
     this.eventListener     = eventListener;
     this.media             = new ArrayList<>();
@@ -109,7 +109,7 @@ public class MediaPickerItemAdapter extends RecyclerView.Adapter<MediaPickerItem
       selectOrder   = itemView.findViewById(R.id.mediapicker_select_order);
     }
 
-    void bind(@NonNull Media media, boolean multiSelect, List<Media> selected, int maxSelection, @NonNull GlideRequests glideRequests, @NonNull EventListener eventListener) {
+    void bind(@NonNull Media media, boolean multiSelect, List<Media> selected, int maxSelection, @NonNull RequestManager glideRequests, @NonNull EventListener eventListener) {
       glideRequests.load(media.getUri())
                    .diskCacheStrategy(DiskCacheStrategy.NONE)
                    .transition(DrawableTransitionOptions.withCrossFade())

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaPickerItemFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaPickerItemFragment.java
@@ -21,7 +21,7 @@ import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.widget.Toast;
 
-import org.thoughtcrime.securesms.mms.GlideApp;
+import com.bumptech.glide.Glide;
 import org.session.libsession.utilities.Util;
 
 import java.util.ArrayList;
@@ -91,7 +91,7 @@ public class MediaPickerItemFragment extends Fragment implements MediaPickerItem
 
     RecyclerView imageList = view.findViewById(R.id.mediapicker_item_list);
 
-    adapter       = new MediaPickerItemAdapter(GlideApp.with(this), this, maxSelection);
+    adapter       = new MediaPickerItemAdapter(Glide.with(this), this, maxSelection);
     layoutManager = new GridLayoutManager(requireContext(), 4);
 
     imageList.setLayoutManager(layoutManager);

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaSendFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaSendFragment.java
@@ -41,7 +41,7 @@ import org.thoughtcrime.securesms.util.SimpleTextWatcher;
 import org.thoughtcrime.securesms.imageeditor.model.EditorModel;
 import org.session.libsignal.utilities.Log;
 import org.thoughtcrime.securesms.mediapreview.MediaRailAdapter;
-import org.thoughtcrime.securesms.mms.GlideApp;
+import com.bumptech.glide.Glide;
 import org.thoughtcrime.securesms.providers.BlobProvider;
 import org.session.libsession.utilities.recipients.Recipient;
 import org.thoughtcrime.securesms.scribbles.ImageEditorFragment;
@@ -187,7 +187,7 @@ public class MediaSendFragment extends Fragment implements ViewTreeObserver.OnGl
     fragmentPager.addOnPageChangeListener(pageChangeListener);
     fragmentPager.post(() -> pageChangeListener.onPageSelected(fragmentPager.getCurrentItem()));
 
-    mediaRailAdapter = new MediaRailAdapter(GlideApp.with(this), this, true);
+    mediaRailAdapter = new MediaRailAdapter(Glide.with(this), this, true);
     mediaRail.setLayoutManager(new LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false));
     mediaRail.setAdapter(mediaRailAdapter);
 

--- a/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaSendGifFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/mediasend/MediaSendGifFragment.java
@@ -12,7 +12,7 @@ import android.widget.ImageView;
 
 import network.loki.messenger.R;
 import org.thoughtcrime.securesms.mms.DecryptableStreamUriLoader;
-import org.thoughtcrime.securesms.mms.GlideApp;
+import com.bumptech.glide.Glide;
 
 public class MediaSendGifFragment extends Fragment implements MediaSendPageFragment {
 
@@ -40,7 +40,7 @@ public class MediaSendGifFragment extends Fragment implements MediaSendPageFragm
     super.onViewCreated(view, savedInstanceState);
 
     uri = getArguments().getParcelable(KEY_URI);
-    GlideApp.with(this).load(new DecryptableStreamUriLoader.DecryptableUri(uri)).into((ImageView) view);
+    Glide.with(this).load(new DecryptableStreamUriLoader.DecryptableUri(uri)).into((ImageView) view);
   }
 
   @Override

--- a/app/src/main/java/org/thoughtcrime/securesms/messagerequests/MessageRequestView.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/messagerequests/MessageRequestView.kt
@@ -11,7 +11,7 @@ import network.loki.messenger.databinding.ViewMessageRequestBinding
 import org.session.libsession.utilities.recipients.Recipient
 import org.thoughtcrime.securesms.conversation.v2.utilities.MentionUtilities.highlightMentions
 import org.thoughtcrime.securesms.database.model.ThreadRecord
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.RequestManager
 import org.thoughtcrime.securesms.util.DateUtils
 import java.util.Locale
 
@@ -32,7 +32,7 @@ class MessageRequestView : LinearLayout {
     // endregion
 
     // region Updating
-    fun bind(thread: ThreadRecord, glide: GlideRequests) {
+    fun bind(thread: ThreadRecord, glide: RequestManager) {
         this.thread = thread
 
         val senderDisplayName = getUserDisplayName(thread.recipient) ?: thread.recipient.address.toString()

--- a/app/src/main/java/org/thoughtcrime/securesms/messagerequests/MessageRequestsActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/messagerequests/MessageRequestsActivity.kt
@@ -17,8 +17,8 @@ import org.thoughtcrime.securesms.PassphraseRequiredActionBarActivity
 import org.thoughtcrime.securesms.conversation.v2.ConversationActivityV2
 import org.thoughtcrime.securesms.database.ThreadDatabase
 import org.thoughtcrime.securesms.database.model.ThreadRecord
-import org.thoughtcrime.securesms.mms.GlideApp
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.Glide
+import com.bumptech.glide.RequestManager
 import org.thoughtcrime.securesms.showSessionDialog
 import org.thoughtcrime.securesms.util.ConfigurationMessageUtilities
 import org.thoughtcrime.securesms.util.push
@@ -28,7 +28,7 @@ import javax.inject.Inject
 class MessageRequestsActivity : PassphraseRequiredActionBarActivity(), ConversationClickListener, LoaderManager.LoaderCallbacks<Cursor> {
 
     private lateinit var binding: ActivityMessageRequestsBinding
-    private lateinit var glide: GlideRequests
+    private lateinit var glide: RequestManager
 
     @Inject lateinit var threadDb: ThreadDatabase
 
@@ -43,7 +43,7 @@ class MessageRequestsActivity : PassphraseRequiredActionBarActivity(), Conversat
         binding = ActivityMessageRequestsBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        glide = GlideApp.with(this)
+        glide = Glide.with(this)
 
         adapter.setHasStableIds(true)
         adapter.glide = glide

--- a/app/src/main/java/org/thoughtcrime/securesms/messagerequests/MessageRequestsAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/messagerequests/MessageRequestsAdapter.kt
@@ -14,7 +14,7 @@ import org.session.libsession.utilities.ThemeUtil
 import org.thoughtcrime.securesms.database.CursorRecyclerViewAdapter
 import org.thoughtcrime.securesms.database.model.ThreadRecord
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent
-import org.thoughtcrime.securesms.mms.GlideRequests
+import com.bumptech.glide.RequestManager
 
 class MessageRequestsAdapter(
     context: Context,
@@ -22,7 +22,7 @@ class MessageRequestsAdapter(
     val listener: ConversationClickListener
 ) : CursorRecyclerViewAdapter<MessageRequestsAdapter.ViewHolder>(context, cursor) {
     private val threadDatabase = DatabaseComponent.get(context).threadDatabase()
-    lateinit var glide: GlideRequests
+    lateinit var glide: RequestManager
 
     class ViewHolder(val view: MessageRequestView) : RecyclerView.ViewHolder(view)
 

--- a/app/src/main/java/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
@@ -38,7 +38,7 @@ import org.session.libsignal.utilities.Log;
 import org.thoughtcrime.securesms.database.SessionContactDatabase;
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent;
 import org.thoughtcrime.securesms.mms.DecryptableStreamUriLoader;
-import org.thoughtcrime.securesms.mms.GlideApp;
+import com.bumptech.glide.Glide;
 import org.thoughtcrime.securesms.mms.Slide;
 import org.thoughtcrime.securesms.mms.SlideDeck;
 import org.thoughtcrime.securesms.util.AvatarPlaceholderGenerator;
@@ -89,7 +89,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
         try {
           // AC: For some reason, if not use ".asBitmap()" method, the returned BitmapDrawable
           // wraps a recycled bitmap and leads to a crash.
-          Bitmap iconBitmap = GlideApp.with(context.getApplicationContext())
+          Bitmap iconBitmap = Glide.with(context.getApplicationContext())
                   .asBitmap()
                   .load(contactPhoto)
                   .diskCacheStrategy(DiskCacheStrategy.NONE)
@@ -291,7 +291,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
       @SuppressWarnings("ConstantConditions")
       Uri uri = slideDeck.getThumbnailSlide().getThumbnailUri();
 
-      return GlideApp.with(context.getApplicationContext())
+      return Glide.with(context.getApplicationContext())
                      .asBitmap()
                      .load(new DecryptableStreamUriLoader.DecryptableUri(uri))
                      .diskCacheStrategy(DiskCacheStrategy.NONE)

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/BlockedContactsAdapter.kt
@@ -9,7 +9,7 @@ import androidx.recyclerview.widget.RecyclerView
 import network.loki.messenger.R
 import network.loki.messenger.databinding.BlockedContactLayoutBinding
 import org.session.libsession.utilities.recipients.Recipient
-import org.thoughtcrime.securesms.mms.GlideApp
+import com.bumptech.glide.Glide
 import org.thoughtcrime.securesms.util.adapter.SelectableItem
 
 typealias SelectableRecipient = SelectableItem<Recipient>
@@ -43,7 +43,7 @@ class BlockedContactsAdapter(val viewModel: BlockedContactsViewModel) : ListAdap
 
     class ViewHolder(itemView: View): RecyclerView.ViewHolder(itemView) {
 
-        val glide = GlideApp.with(itemView)
+        val glide = Glide.with(itemView)
         val binding = BlockedContactLayoutBinding.bind(itemView)
 
         fun bind(selectable: SelectableRecipient, toggle: (SelectableRecipient) -> Unit) {

--- a/app/src/main/java/org/thoughtcrime/securesms/preferences/RadioOptionAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/preferences/RadioOptionAdapter.kt
@@ -10,7 +10,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import network.loki.messenger.R
 import network.loki.messenger.databinding.ItemSelectableBinding
-import org.thoughtcrime.securesms.mms.GlideApp
+import com.bumptech.glide.Glide
 import org.thoughtcrime.securesms.ui.GetString
 import java.util.Objects
 
@@ -45,7 +45,7 @@ class RadioOptionAdapter<T>(
     }
 
     class ViewHolder<T>(itemView: View): RecyclerView.ViewHolder(itemView) {
-        val glide = GlideApp.with(itemView)
+        val glide = Glide.with(itemView)
         val binding = ItemSelectableBinding.bind(itemView)
 
         fun bind(option: RadioOption<T>, isSelected: Boolean, toggleSelection: (RadioOption<T>) -> Unit) {

--- a/app/src/main/java/org/thoughtcrime/securesms/reactions/ReactionRecipientsAdapter.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/reactions/ReactionRecipientsAdapter.java
@@ -13,7 +13,7 @@ import org.session.libsession.messaging.utilities.AccountId;
 import org.thoughtcrime.securesms.components.ProfilePictureView;
 import org.thoughtcrime.securesms.components.emoji.EmojiImageView;
 import org.thoughtcrime.securesms.database.model.MessageId;
-import org.thoughtcrime.securesms.mms.GlideApp;
+import com.bumptech.glide.Glide;
 
 import java.util.Collections;
 import java.util.List;

--- a/app/src/main/java/org/thoughtcrime/securesms/scribbles/StickerSelectFragment.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/scribbles/StickerSelectFragment.java
@@ -37,13 +37,13 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy;
 
 
 import network.loki.messenger.R;
-import org.thoughtcrime.securesms.mms.GlideApp;
-import org.thoughtcrime.securesms.mms.GlideRequests;
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.RequestManager;
 
 public class StickerSelectFragment extends Fragment implements LoaderManager.LoaderCallbacks<String[]> {
 
   private RecyclerView             recyclerView;
-  private GlideRequests glideRequests;
+  private RequestManager glideRequests;
   private String                   assetDirectory;
   private StickerSelectionListener listener;
 
@@ -71,7 +71,7 @@ public class StickerSelectFragment extends Fragment implements LoaderManager.Loa
   public void onActivityCreated(Bundle bundle) {
     super.onActivityCreated(bundle);
 
-    this.glideRequests  = GlideApp.with(this);
+    this.glideRequests  = Glide.with(this);
     this.assetDirectory = getArguments().getString("assetDirectory");
 
     getLoaderManager().initLoader(0, null, this);
@@ -99,11 +99,11 @@ public class StickerSelectFragment extends Fragment implements LoaderManager.Loa
 
   class StickersAdapter extends RecyclerView.Adapter<StickersAdapter.StickerViewHolder> {
 
-    private final GlideRequests  glideRequests;
+    private final RequestManager  glideRequests;
     private final String[]       stickerFiles;
     private final LayoutInflater layoutInflater;
 
-    StickersAdapter(@NonNull Context context, @NonNull GlideRequests glideRequests, @NonNull String[] stickerFiles) {
+    StickersAdapter(@NonNull Context context, @NonNull RequestManager glideRequests, @NonNull String[] stickerFiles) {
       this.glideRequests  = glideRequests;
       this.stickerFiles   = stickerFiles;
       this.layoutInflater = LayoutInflater.from(context);

--- a/app/src/main/java/org/thoughtcrime/securesms/scribbles/UriGlideRenderer.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/scribbles/UriGlideRenderer.java
@@ -11,6 +11,7 @@ import android.os.Parcel;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.bumptech.glide.RequestBuilder;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.request.target.SimpleTarget;
 import com.bumptech.glide.request.transition.Transition;
@@ -20,8 +21,7 @@ import org.thoughtcrime.securesms.imageeditor.Bounds;
 import org.thoughtcrime.securesms.imageeditor.Renderer;
 import org.thoughtcrime.securesms.imageeditor.RendererContext;
 import org.thoughtcrime.securesms.mms.DecryptableStreamUriLoader;
-import org.thoughtcrime.securesms.mms.GlideApp;
-import org.thoughtcrime.securesms.mms.GlideRequest;
+import com.bumptech.glide.Glide;
 
 import java.util.concurrent.ExecutionException;
 
@@ -97,8 +97,8 @@ final class UriGlideRenderer implements Renderer {
     }
   }
 
-  private GlideRequest<Bitmap> getBitmapGlideRequest(@NonNull Context context) {
-    return GlideApp.with(context)
+  private RequestBuilder<Bitmap> getBitmapGlideRequest(@NonNull Context context) {
+    return Glide.with(context)
                    .asBitmap()
                    .diskCacheStrategy(DiskCacheStrategy.NONE)
                    .override(maxWidth, maxHeight)

--- a/app/src/main/java/org/thoughtcrime/securesms/service/DirectShareService.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/service/DirectShareService.java
@@ -19,7 +19,7 @@ import org.thoughtcrime.securesms.ShareActivity;
 import org.thoughtcrime.securesms.database.ThreadDatabase;
 import org.thoughtcrime.securesms.database.model.ThreadRecord;
 import org.thoughtcrime.securesms.dependencies.DatabaseComponent;
-import org.thoughtcrime.securesms.mms.GlideApp;
+import com.bumptech.glide.Glide;
 import org.thoughtcrime.securesms.util.BitmapUtil;
 
 import java.util.LinkedList;
@@ -50,7 +50,7 @@ public class DirectShareService extends ChooserTargetService {
 
               if (recipient.getContactPhoto() != null) {
                   try {
-                      avatar = GlideApp.with(this)
+                      avatar = Glide.with(this)
                               .asBitmap()
                               .load(recipient.getContactPhoto())
                               .circleCrop()

--- a/app/src/main/java/org/thoughtcrime/securesms/util/BitmapUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/BitmapUtil.java
@@ -20,7 +20,7 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy;
 
 import org.session.libsession.utilities.MediaTypes;
 import org.session.libsignal.utilities.Log;
-import org.thoughtcrime.securesms.mms.GlideApp;
+import com.bumptech.glide.Glide;
 import org.thoughtcrime.securesms.mms.MediaConstraints;
 
 import org.session.libsession.utilities.Util;
@@ -98,7 +98,7 @@ public class BitmapUtil {
       int    attempts = 0;
       byte[] bytes;
 
-      Bitmap scaledBitmap = GlideApp.with(context.getApplicationContext())
+      Bitmap scaledBitmap = Glide.with(context.getApplicationContext())
                                     .asBitmap()
                                     .load(model)
                                     .skipMemoryCache(true)
@@ -164,7 +164,7 @@ public class BitmapUtil {
       throws BitmapDecodingException
   {
     try {
-      return GlideApp.with(context.getApplicationContext())
+      return Glide.with(context.getApplicationContext())
                      .asBitmap()
                      .load(model)
                      .centerInside()

--- a/app/src/main/java/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -22,7 +22,7 @@ import org.thoughtcrime.securesms.mms.AudioSlide;
 import org.thoughtcrime.securesms.mms.DecryptableStreamUriLoader.DecryptableUri;
 import org.thoughtcrime.securesms.mms.DocumentSlide;
 import org.thoughtcrime.securesms.mms.GifSlide;
-import org.thoughtcrime.securesms.mms.GlideApp;
+import com.bumptech.glide.Glide;
 import org.thoughtcrime.securesms.mms.ImageSlide;
 import org.thoughtcrime.securesms.mms.MmsSlide;
 import org.thoughtcrime.securesms.mms.PartAuthority;
@@ -115,7 +115,7 @@ public class MediaUtil {
 
     if (MediaUtil.isGif(contentType)) {
       try {
-        GifDrawable drawable = GlideApp.with(context)
+        GifDrawable drawable = Glide.with(context)
                 .asGif()
                 .skipMemoryCache(true)
                 .diskCacheStrategy(DiskCacheStrategy.NONE)

--- a/build.gradle
+++ b/build.gradle
@@ -17,13 +17,15 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlinVersion"
         classpath "com.google.gms:google-services:$googleServicesVersion"
         classpath "com.squareup:javapoet:1.13.0"
-        classpath "com.google.dagger:hilt-android-gradle-plugin:$daggerVersion"
         if (project.hasProperty('huawei')) classpath 'com.huawei.agconnect:agcp:1.9.1.300'
     }
 }
 
-plugins{
-    id("com.google.dagger.hilt.android") version "2.44" apply false
+// List plugins AND their versions here, but don't apply. This allows you to use the plugin
+// in your module without specifying the version.
+plugins {
+    id 'com.google.devtools.ksp' version "$kotlinVersion-1.0.20" apply false
+    id 'com.google.dagger.hilt.android' version "$daggerHiltVersion" apply false
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,6 @@
 android.enableJetifier=true
 
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
-#org.gradle.unsafe.configuration-cach/e=true
 
 gradlePluginVersion=7.3.1
 googleServicesVersion=4.3.12

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,19 +14,20 @@
 android.enableJetifier=true
 
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
-org.gradle.unsafe.configuration-cache=true
+#org.gradle.unsafe.configuration-cach/e=true
 
 gradlePluginVersion=7.3.1
 googleServicesVersion=4.3.12
-kotlinVersion=1.8.21
+kotlinVersion=1.9.24
 android.useAndroidX=true
 appcompatVersion=1.6.1
 coreVersion=1.13.1
 composeVersion=1.6.4
 coroutinesVersion=1.6.4
 curve25519Version=0.6.0
-daggerVersion=2.46.1
-glideVersion=4.11.0
+jetpackHiltVersion=1.2.0
+daggerHiltVersion=2.51.1
+glideVersion=4.16.0
 jacksonDatabindVersion=2.9.8
 junitVersion=4.13.2
 kotlinxJsonVersion=1.3.3

--- a/libsession/build.gradle
+++ b/libsession/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'com.android.library'
     id 'kotlin-android'
     id 'kotlinx-serialization'
+    id 'com.google.devtools.ksp'
+    id 'com.google.dagger.hilt.android'
 }
 
 android {
@@ -21,6 +23,11 @@ dependencies {
     implementation project(":libsignal")
     implementation project(":libsession-util")
     implementation project(":liblazysodium")
+
+    implementation("com.google.dagger:hilt-android:$daggerHiltVersion")
+    ksp("com.google.dagger:hilt-compiler:$daggerHiltVersion")
+    ksp("androidx.hilt:hilt-compiler:$jetpackHiltVersion")
+
     implementation "net.java.dev.jna:jna:5.12.1@aar"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation "androidx.core:core-ktx:$coreVersion"
@@ -28,7 +35,6 @@ dependencies {
     implementation "androidx.preference:preference-ktx:$preferenceVersion"
     implementation "com.google.android.material:material:$materialVersion"
     implementation "com.google.protobuf:protobuf-java:$protobufVersion"
-    implementation "com.google.dagger:hilt-android:$daggerVersion"
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     implementation "com.github.bumptech.glide:glide:$glideVersion"


### PR DESCRIPTION
In order to use KSP, I have to:
1. Update kotlin version to the 1.9.x series (updating to 2.0 seems a bit risky at this moment)
2. Update compose compiler to match the kotlin update
3. Deprecated generated APIs aren't usable anymore in Glide so I followed the official guide to do the replacement (https://bumptech.github.io/glide/doc/generatedapi.html)