### PR TITLE
[QA-32] Fix app closes on app-unlock

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -125,7 +125,7 @@
         <activity
             android:name="org.thoughtcrime.securesms.home.HomeActivity"
             android:screenOrientation="portrait"
-            android:launchMode="standard"
+            android:launchMode="singleTask"
             android:theme="@style/Theme.Session.DayNight.NoActionBar" />
         <activity
             android:name="org.thoughtcrime.securesms.messagerequests.MessageRequestsActivity"

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeActivity.kt
@@ -142,8 +142,6 @@ class HomeActivity : PassphraseRequiredActionBarActivity(),
     override fun onCreate(savedInstanceState: Bundle?, isReady: Boolean) {
         super.onCreate(savedInstanceState, isReady)
 
-        if (!isTaskRoot) { finish(); return }
-
         // Set content view
         binding = ActivityHomeBinding.inflate(layoutInflater)
         setContentView(binding.root)


### PR DESCRIPTION
Added `launchMode=singleTask` to `HomeActivity`

Removed the check that `HomeActivity` was the root task, as it should now be enforced.