### PR TITLE
Fix double closing on memory file

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/MemoryFileUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/MemoryFileUtil.java
@@ -22,7 +22,7 @@ public class MemoryFileUtil {
 
       int fd = field.getInt(fileDescriptor);
 
-      return ParcelFileDescriptor.adoptFd(fd);
+      return ParcelFileDescriptor.fromFd(fd);
     } catch (IllegalAccessException e) {
       throw new IOException(e);
     } catch (InvocationTargetException e) {


### PR DESCRIPTION
It should be able to fix this issue:

```
*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
pid: 0, tid: 25649 >>> network.loki.messenger <<<

backtrace:
  #00  pc 0x000000000009988c  /apex/com.android.runtime/lib64/bionic/libc.so (fdsan_error(char const*, ...)+564)
  #01  pc 0x0000000000099590  /apex/com.android.runtime/lib64/bionic/libc.so (android_fdsan_close_with_tag+920)
  #02  pc 0x00000000000264f8  /apex/com.android.art/lib64/libjavacore.so (Linux_close(_JNIEnv*, _jobject*, _jobject*)+104)
  #03  pc 0x000000000033e310  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (art_jni_trampoline+128)
  #04  pc 0x00000000005f1468  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (libcore.io.BlockGuardOs.close+824)
  #05  pc 0x00000000005ebaa0  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (libcore.io.ForwardingOs.close+64)
  #06  pc 0x00000000005b47bc  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (android.system.Os.close+76)
  #07  pc 0x00000000005ba818  /apex/com.android.art/lib64/libart.so (nterp_helper+152)
  #08  pc 0x0000000000256c74  /system/framework/framework.jar (android.os.SharedMemory$Closer.run+20)
  #09  pc 0x0000000000510778  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (sun.misc.Cleaner.clean+88)
  #10  pc 0x000000000037a188  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (java.lang.ref.ReferenceQueue.enqueuePending+392)
  #11  pc 0x00000000005eb380  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (java.lang.Daemons$ReferenceQueueDaemon.runInternal+576)
  #12  pc 0x00000000005c034c  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (java.lang.Daemons$Daemon.run+156)
  #13  pc 0x000000000041c970  /data/misc/apexdata/com.android.art/dalvik-cache/arm64/boot.oat (java.lang.Thread.run+64)
  #14  pc 0x000000000033eba4  /apex/com.android.art/lib64/libart.so (art_quick_invoke_stub+612)
  #15  pc 0x000000000023a9ac  /apex/com.android.art/lib64/libart.so (art::ArtMethod::Invoke(art::Thread*, unsigned int*, unsigned int, art::JValue*, char const*)+144)
  #16  pc 0x000000000053b96c  /apex/com.android.art/lib64/libart.so (art::Thread::CreateCallback(void*)+1600)
  #17  pc 0x000000000053b31c  /apex/com.android.art/lib64/libart.so (art::Thread::CreateCallbackWithUffdGc(void*)+8)
  #18  pc 0x00000000000fd0f4  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+208)
  #19  pc 0x0000000000096a04  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+68)
```