### PR TITLE
Removing the snodes version patch

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -215,16 +215,6 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
         MessagingModuleConfiguration.configure(this);
         super.onCreate();
 
-        // we need to clear the snode and onionrequest databases once on first launch
-        // in order to apply a patch that adds a version number to the Snode objects.
-        if(!TextSecurePreferences.hasAppliedPatchSnodeVersion(this)) {
-            ThreadUtils.queue(() -> {
-                lokiAPIDatabase.clearSnodePool();
-                lokiAPIDatabase.clearOnionRequestPaths();
-                TextSecurePreferences.setHasAppliedPatchSnodeVersion(this, true);
-            });
-        }
-
         messagingModuleConfiguration = new MessagingModuleConfiguration(
                 this,
                 storage,

--- a/libsession/src/main/java/org/session/libsession/snode/OnionRequestAPI.kt
+++ b/libsession/src/main/java/org/session/libsession/snode/OnionRequestAPI.kt
@@ -193,17 +193,6 @@ object OnionRequestAPI {
                     val result = listOf( guardSnode ) + (0 until (pathSize - 1)).mapIndexed() { index, _ ->
                         var pathSnode = unusedSnodes.getRandomElement()
 
-                        // For the last node: We need to make sure the version is >= 2.8.0
-                        // to help with an issue that will disappear once the nodes are all updated
-                        if(index == pathSize - 2) {
-                            val suitableSnodes = unusedSnodes.filter { Util.compareVersions(it.version, "2.8.0") >= 0 }
-                            pathSnode = if (suitableSnodes.isNotEmpty()) {
-                                suitableSnodes.random()
-                            } else {
-                                throw InsufficientSnodesException()
-                            }
-                        }
-
                         // remove the snode from the unused list and return it
                         unusedSnodes = unusedSnodes.minus(pathSnode)
                         pathSnode

--- a/libsession/src/main/java/org/session/libsession/utilities/TextSecurePreferences.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/TextSecurePreferences.kt
@@ -296,8 +296,6 @@ interface TextSecurePreferences {
 
         const val ALLOW_MESSAGE_REQUESTS = "libsession.ALLOW_MESSAGE_REQUESTS"
 
-        const val PATCH_SNODE_VERSION_2024_07_23 = "libsession.patch_snode_version_2024_07_23"
-
         @JvmStatic
         fun getLastConfigurationSyncTime(context: Context): Long {
             return getLongPreference(context, LAST_CONFIGURATION_SYNC_TIME, 0)
@@ -981,16 +979,6 @@ interface TextSecurePreferences {
         @JvmStatic
         fun clearAll(context: Context) {
             getDefaultSharedPreferences(context).edit().clear().commit()
-        }
-
-        @JvmStatic
-        fun hasAppliedPatchSnodeVersion(context: Context): Boolean {
-            return getBooleanPreference(context, PATCH_SNODE_VERSION_2024_07_23, false)
-        }
-
-        @JvmStatic
-        fun setHasAppliedPatchSnodeVersion(context: Context, applied: Boolean) {
-            setBooleanPreference(context, PATCH_SNODE_VERSION_2024_07_23, applied)
         }
     }
 }


### PR DESCRIPTION
All the service nodes should be updated moving forward so the patch is no longer required.