### PR TITLE
Feature/clean ups

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiVariationSelectorPopup.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/components/emoji/EmojiVariationSelectorPopup.java
@@ -1,12 +1,15 @@
 package org.thoughtcrime.securesms.components.emoji;
 
 import android.content.Context;
+import android.graphics.drawable.ColorDrawable;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.PopupWindow;
 
 import androidx.annotation.NonNull;
+
+import org.session.libsession.utilities.ThemeUtil;
 
 import java.util.List;
 
@@ -26,7 +29,9 @@ public class EmojiVariationSelectorPopup extends PopupWindow {
     this.listener = listener;
     this.list     = (ViewGroup) getContentView();
 
-    setBackgroundDrawable(null);
+    setBackgroundDrawable(
+            new ColorDrawable(ThemeUtil.getThemedColor(context, R.attr.colorPrimary))
+    );
     setOutsideTouchable(true);
   }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationViewModel.kt
@@ -261,8 +261,14 @@ class ConversationViewModel(
         _recipient.updateTo(repository.maybeGetRecipientForThreadId(threadId))
     }
 
-    fun hidesInputBar(): Boolean = openGroup?.canWrite != true &&
-        blindedRecipient?.blocksCommunityMessageRequests == true
+    /**
+     * The input should be hidden when:
+     * - We are in a community without write access
+     * - We are dealing with a contact from a community (blinded recipient) that does not allow
+     *   requests form community members
+     */
+    fun hidesInputBar(): Boolean = openGroup?.canWrite == false ||
+            blindedRecipient?.blocksCommunityMessageRequests == true
 
     fun legacyBannerRecipient(context: Context): Recipient? = recipient?.run {
         storage.getLastLegacyRecipient(address.serialize())?.let { Recipient.from(context, Address.fromSerialized(it), false) }

--- a/app/src/main/java/org/thoughtcrime/securesms/home/HomeAdapter.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/home/HomeAdapter.kt
@@ -104,7 +104,6 @@ class HomeAdapter(
                 holder.binding.run {
                     messageRequests?.let {
                         unreadCountTextView.text = it.count
-                        timestampTextView.text = it.timestamp
                     }
                 }
             }

--- a/app/src/main/res/layout/view_message_request_banner.xml
+++ b/app/src/main/res/layout/view_message_request_banner.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@drawable/conversation_view_background"
+    android:background="@drawable/conversation_unread_background"
     android:contentDescription="@string/AccessibilityId_message_request_banner"
     android:gravity="center_vertical"
     android:orientation="horizontal"
@@ -19,7 +19,8 @@
         android:layout_marginStart="@dimen/medium_spacing"
         android:padding="10dp"
         android:src="@drawable/ic_outline_message_requests_24"
-        app:circleColor="#585858"
+        android:tint="?unreadIndicatorTextColor"
+        app:circleColor="?unreadIndicatorBackgroundColor"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -47,7 +48,7 @@
         android:layout_height="20dp"
         android:layout_marginStart="4dp"
         android:background="@drawable/circle_tintable"
-        android:backgroundTint="#585858"
+        android:backgroundTint="?unreadIndicatorBackgroundColor"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@id/conversationViewDisplayNameTextView"
         app:layout_constraintTop_toTopOf="parent">
@@ -57,30 +58,11 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"
-            android:textColor="@color/white"
+            android:textColor="?unreadIndicatorTextColor"
             android:textSize="@dimen/very_small_font_size"
             android:textStyle="bold"
             tools:text="8" />
 
     </RelativeLayout>
-
-    <TextView
-        android:id="@+id/timestampTextView"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/medium_spacing"
-        android:alpha="0.4"
-        android:ellipsize="end"
-        android:maxLines="1"
-        android:textAlignment="textEnd"
-        android:textColor="?android:textColorPrimary"
-        android:textSize="@dimen/small_font_size"
-        app:layout_constrainedWidth="true"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="1"
-        app:layout_constraintStart_toEndOf="@id/unreadCountIndicator"
-        app:layout_constraintTop_toTopOf="parent"
-        tools:text="11 Apr, 9:41 AM" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
[SES-2494](https://optf.atlassian.net/browse/SES-2494) - Message request styling. Applying the appropriate styling as decided in the [notion doc](https://www.notion.so/oxen/Android-issues-4e30d0c5dd6345d39f882794a1cf187a?pvs=4#1f17258c469045c1bcc9c9b0547ff278).
[SES-2443](https://optf.atlassian.net/browse/SES-2443) - Adding a bg to the emoji variation picker
[SES-1700](https://optf.atlassian.net/browse/SES-1700) - Cleaned up the logic to hide the text input in the conversation