### PR TITLE
Updated to latest web-rtc library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -271,7 +271,7 @@ dependencies {
     implementation 'com.google.android.exoplayer:exoplayer-ui:2.9.1'
     implementation 'org.conscrypt:conscrypt-android:2.5.2'
     implementation 'org.signal:aesgcmprovider:0.0.3'
-    implementation 'org.webrtc:google-webrtc:1.0.32006'
+    implementation 'io.github.webrtc-sdk:android:125.6422.04'
     implementation "me.leolin:ShortcutBadger:1.1.16"
     implementation 'se.emilsjolander:stickylistheaders:2.7.0'
     implementation 'com.jpardogo.materialtabstrip:library:1.0.9'

--- a/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/ApplicationContext.java
@@ -23,7 +23,6 @@ import android.app.Application;
 import android.content.Context;
 import android.content.Intent;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
 
@@ -91,8 +90,6 @@ import org.thoughtcrime.securesms.util.dynamiclanguage.LocaleParseHelper;
 import org.thoughtcrime.securesms.webrtc.CallMessageProcessor;
 import org.webrtc.PeerConnectionFactory;
 import org.webrtc.PeerConnectionFactory.InitializationOptions;
-import org.webrtc.voiceengine.WebRtcAudioManager;
-import org.webrtc.voiceengine.WebRtcAudioUtils;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -100,9 +97,7 @@ import java.io.InputStream;
 import java.security.Security;
 import java.util.Arrays;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.Timer;
 import java.util.concurrent.Executors;
 
@@ -394,33 +389,6 @@ public class ApplicationContext extends Application implements DefaultLifecycleO
 
     private void initializeWebRtc() {
         try {
-            Set<String> HARDWARE_AEC_BLACKLIST = new HashSet<String>() {{
-                add("Pixel");
-                add("Pixel XL");
-                add("Moto G5");
-                add("Moto G (5S) Plus");
-                add("Moto G4");
-                add("TA-1053");
-                add("Mi A1");
-                add("E5823"); // Sony z5 compact
-                add("Redmi Note 5");
-                add("FP2"); // Fairphone FP2
-                add("MI 5");
-            }};
-
-            Set<String> OPEN_SL_ES_WHITELIST = new HashSet<String>() {{
-                add("Pixel");
-                add("Pixel XL");
-            }};
-
-            if (HARDWARE_AEC_BLACKLIST.contains(Build.MODEL)) {
-                WebRtcAudioUtils.setWebRtcBasedAcousticEchoCanceler(true);
-            }
-
-            if (!OPEN_SL_ES_WHITELIST.contains(Build.MODEL)) {
-                WebRtcAudioManager.setBlacklistDeviceForOpenSLESUsage(true);
-            }
-
             PeerConnectionFactory.initialize(InitializationOptions.builder(this).createInitializationOptions());
         } catch (UnsatisfiedLinkError e) {
             Log.w(TAG, e);

--- a/app/src/main/java/org/thoughtcrime/securesms/webrtc/PeerConnectionWrapper.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/webrtc/PeerConnectionWrapper.kt
@@ -73,7 +73,10 @@ class PeerConnectionWrapper(private val context: Context,
         newPeerConnection.setAudioPlayout(true)
         newPeerConnection.setAudioRecording(true)
 
-        newPeerConnection.addStream(mediaStream)
+        // Calls to `addStream` are deprecated & cause errors so we must use `addTracks` when
+        // using `io.github.webrtc-sdk:android:114.5735.10` and newer.
+        newPeerConnection.addTrack(mediaStream.audioTracks[0])
+        if (mediaStream.videoTracks.isNotEmpty()) newPeerConnection.addTrack(mediaStream.videoTracks[0])
     }
 
     init {

--- a/app/src/main/java/org/thoughtcrime/securesms/webrtc/PeerConnectionWrapper.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/webrtc/PeerConnectionWrapper.kt
@@ -63,6 +63,7 @@ class PeerConnectionWrapper(private val context: Context,
         val configuration = PeerConnection.RTCConfiguration(iceServers).apply {
             bundlePolicy = PeerConnection.BundlePolicy.MAXBUNDLE
             rtcpMuxPolicy = PeerConnection.RtcpMuxPolicy.REQUIRE
+            sdpSemantics = PeerConnection.SdpSemantics.PLAN_B
             if (relay) {
                 iceTransportsType = PeerConnection.IceTransportsType.RELAY
             }
@@ -73,10 +74,7 @@ class PeerConnectionWrapper(private val context: Context,
         newPeerConnection.setAudioPlayout(true)
         newPeerConnection.setAudioRecording(true)
 
-        // Calls to `addStream` are deprecated & cause errors so we must use `addTracks` when
-        // using `io.github.webrtc-sdk:android:114.5735.10` and newer.
-        newPeerConnection.addTrack(mediaStream.audioTracks[0])
-        if (mediaStream.videoTracks.isNotEmpty()) newPeerConnection.addTrack(mediaStream.videoTracks[0])
+        newPeerConnection.addStream(mediaStream)
     }
 
     init {


### PR DESCRIPTION
It seems setWebRtcBasedAcousticEchoCanceler and setBlacklistDeviceForOpenSLESUsage are no longer available. What this means is unclear and the new library might be handling certain things internally
