### PR TITLE
Fix/ip2 country out of memory

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/IP2Country.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/IP2Country.kt
@@ -17,9 +17,26 @@ class IP2Country private constructor(private val context: Context) {
     private val pathsBuiltEventReceiver: BroadcastReceiver
     val countryNamesCache = mutableMapOf<String, String>()
 
-    private fun Ipv4Int(ip:String) = ip.takeWhile { it != '/' }.split('.').foldIndexed(0L) { i, acc, s ->
-        val asInt = s.toLong()
-        acc + (asInt shl (8 * (3-i)))
+    private fun Ipv4Int(ip: String): Long {
+        var result = 0L
+        var currentValue = 0L
+        var octetIndex = 0
+
+        for (char in ip) {
+            if (char == '.' || char == '/') {
+                result = (result shl 8) or currentValue
+                currentValue = 0
+                octetIndex++
+                if (char == '/') break
+            } else {
+                currentValue = currentValue * 10 + (char - '0')
+            }
+        }
+
+        // Handle the last octet
+        result = (result shl 8) or currentValue
+
+        return result
     }
 
     private val ipv4ToCountry by lazy {

--- a/app/src/main/java/org/thoughtcrime/securesms/util/IP2Country.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/IP2Country.kt
@@ -97,7 +97,8 @@ class IP2Country private constructor(private val context: Context) {
 
         val comps = ipv4ToCountry.asSequence()
 
-        val bestMatchCountry = comps.lastOrNull { it.key <= Ipv4Int(ip)  }?.let { (_, code) ->
+        val ipInt = Ipv4Int(ip)
+        val bestMatchCountry = comps.lastOrNull { it.key <= ipInt  }?.let { (_, code) ->
             if (code != null) {
                 countryToNames[code]
             } else {

--- a/app/src/main/java/org/thoughtcrime/securesms/util/ListUtil.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/ListUtil.java
@@ -2,10 +2,7 @@ package org.thoughtcrime.securesms.util;
 
 import androidx.annotation.NonNull;
 
-import com.annimon.stream.Stream;
-
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 public final class ListUtil {
@@ -20,17 +17,5 @@ public final class ListUtil {
     }
 
     return chunks;
-  }
-
-  @SafeVarargs
-  public static <T> List<T> concat(Collection<T>... items) {
-    //noinspection Convert2MethodRef
-    final List<T> concat = new ArrayList<>(Stream.of(items).map(Collection::size).reduce(0, (lhs, rhs) -> lhs+rhs));
-
-    for (Collection<T> list : items) {
-      concat.addAll(list);
-    }
-
-    return concat;
   }
 }


### PR DESCRIPTION
Helping with the out of memory crash we are getting from the playstore:
https://play.google.com/console/u/0/developers/8294769987979883884/app/4974570314892392602/vitals/crashes/a4b76784091e144fe86ab5a64cb86295/details?days=28&versionCode=3795%2C3785&isUserPerceived=true

Avoid memory allocation in the ipv4Int logic and avoiding reading the whole csv file.