### PR TITLE
SES-2624 Android API 28 crash on save file workaround

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/util/SaveAttachmentTask.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/util/SaveAttachmentTask.kt
@@ -61,7 +61,12 @@ class SaveAttachmentTask @JvmOverloads constructor(context: Context, count: Int 
         fun saveAttachment(context: Context, attachment: Attachment): String? {
             val contentType = checkNotNull(MediaUtil.getCorrectedMimeType(attachment.contentType))
             var fileName = attachment.fileName
-            if (fileName == null) fileName = generateOutputFileName(contentType, attachment.date)
+
+            // Added for SES-2624 to prevent Android API 28 devices and lower from crashing because
+            // for unknown reasons it provides us with an empty filename when saving files.
+            // TODO: Further investigation into root cause and fix!
+            if (fileName.isNullOrEmpty()) fileName = generateOutputFileName(contentType, attachment.date)
+
             fileName = sanitizeOutputFileName(fileName)
             val outputUri: Uri = getMediaStoreContentUriForType(contentType)
             val mediaUri = createOutputUri(context, outputUri, contentType, fileName)


### PR DESCRIPTION
### Description
Workaround to prevent Android API 28 devices from crashing when saving a file. Root-cause analysis required for a proper fix but applying this workaround for the time being as 1.19.2 release is imminent.
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
