### PR TITLE
Subtituted 'Session' into 'Quit Session' text on go-back modal

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/onboarding/OnboardingBackPressAlertDialog.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/onboarding/OnboardingBackPressAlertDialog.kt
@@ -6,10 +6,12 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.squareup.phrase.Phrase
 import network.loki.messenger.R
+import org.session.libsession.utilities.NonTranslatableStringConstants.APP_NAME
 import org.session.libsession.utilities.StringSubstitutionConstants.APP_NAME_KEY
 import org.thoughtcrime.securesms.ui.AlertDialog
 import org.thoughtcrime.securesms.ui.DialogButtonModel
 import org.thoughtcrime.securesms.ui.GetString
+import org.thoughtcrime.securesms.ui.getSubbedString
 import org.thoughtcrime.securesms.ui.theme.LocalColors
 
 @Composable
@@ -18,16 +20,18 @@ fun OnboardingBackPressAlertDialog(
     @StringRes textId: Int = R.string.onboardingBackAccountCreation,
     quit: () -> Unit
 ) {
+    val c = LocalContext.current
+    val quitButtonText = c.getSubbedString(R.string.quit, APP_NAME_KEY to APP_NAME)
+
     AlertDialog(
         onDismissRequest = dismissDialog,
         title = stringResource(R.string.warning),
         text = stringResource(textId).let { txt ->
-            val c = LocalContext.current
             Phrase.from(txt).put(APP_NAME_KEY, c.getString(R.string.app_name)).format().toString()
         },
         buttons = listOf(
             DialogButtonModel(
-                GetString(stringResource(R.string.quit)),
+                text = GetString(quitButtonText),
                 color = LocalColors.current.danger,
                 onClick = quit
             ),


### PR DESCRIPTION
### Description
Performs the substitution of "Session" into the "Quit Session" button text in the onboarding back modal.

<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
