### PR TITLE
Fix ItemButton padding for downstate

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/ui/Components.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/Components.kt
@@ -277,21 +277,19 @@ fun ItemButton(
     TextButton(
         modifier = modifier.fillMaxWidth()
             .height(IntrinsicSize.Min)
-            .heightIn(min = minHeight)
-            .padding(horizontal = LocalDimensions.current.xsSpacing),
+            .heightIn(min = minHeight),
         colors = colors,
         onClick = onClick,
+        contentPadding = PaddingValues(),
         shape = RectangleShape,
     ) {
         Box(
             modifier = Modifier.fillMaxHeight()
-                .aspectRatio(1f)
                 .align(Alignment.CenterVertically)
-        ) {
-            icon()
-        }
-
-        Spacer(modifier = Modifier.width(LocalDimensions.current.smallSpacing))
+                .padding(horizontal = LocalDimensions.current.xxsSpacing)
+                .aspectRatio(1f),
+            content = icon
+        )
 
         Text(
             text,


### PR DESCRIPTION
Padding seems to be set in the wrong place, which cuts off the downstate to some arbitrary position that doesn't line up with anything. This PR reinstates previous behaviour where downstate would extend to edges, matching iOS' downstate dimensions.

### Before

![Screenshot 2024-09-18 at 12 55 30 AM](https://github.com/user-attachments/assets/257733e9-c309-47f9-8915-4a189aa51a6b)

### After

![Screenshot 2024-09-18 at 4 33 41 PM](https://github.com/user-attachments/assets/d69a3da9-c95c-4fc1-a18e-c206ab3c7d3e)

`TextButton` uses some default `contentPadding` with horizontal padding of `12 dp` which is a bit awkward, so this PR sets `contentPadding = PaddingValues()` effectively removing content padding so it can all be set explicitly.

This PR utilises some square space around the icon with an additional xxsSpacing horizontal padding to keep space on each side of the icon equal, and slightly more indented than the divider, which seems to match iOS.

![Screenshot 2024-09-18 at 4 42 01 PM](https://github.com/user-attachments/assets/1d1bcd09-e00d-4a08-b2dc-b9296623735b)
