### PR TITLE
Fix/message request after delete

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/start/home/StartConversation.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/start/home/StartConversation.kt
@@ -66,21 +66,21 @@ internal fun StartConversationScreen(
                     icon = R.drawable.ic_message,
                     modifier = Modifier.contentDescription(R.string.AccessibilityId_messageNew),
                     onClick = delegate::onNewMessageSelected)
-                Divider(startIndent = LocalDimensions.current.dividerIndent)
+                Divider(startIndent = LocalDimensions.current.minItemButtonHeight)
                 ItemButton(
                     textId = R.string.groupCreate,
                     icon = R.drawable.ic_group,
                     modifier = Modifier.contentDescription(R.string.AccessibilityId_groupCreate),
                     onClick = delegate::onCreateGroupSelected
                 )
-                Divider(startIndent = LocalDimensions.current.dividerIndent)
+                Divider(startIndent = LocalDimensions.current.minItemButtonHeight)
                 ItemButton(
                     textId = R.string.communityJoin,
                     icon = R.drawable.ic_globe,
                     modifier = Modifier.contentDescription(R.string.AccessibilityId_communityJoin),
                     onClick = delegate::onJoinCommunitySelected
                 )
-                Divider(startIndent = LocalDimensions.current.dividerIndent)
+                Divider(startIndent = LocalDimensions.current.minItemButtonHeight)
                 ItemButton(
                     textId = R.string.sessionInviteAFriend,
                     icon = R.drawable.ic_invite_friend,

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -1583,6 +1583,7 @@ open class Storage(
         if (recipient.isLocalNumber || !recipient.isContactRecipient) return
         configFactory.contacts?.upsertContact(recipient.address.serialize()) {
             this.approved = approved
+            this.priority = PRIORITY_VISIBLE
         }
     }
 

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/Components.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/Components.kt
@@ -275,19 +275,17 @@ fun ItemButton(
     onClick: () -> Unit
 ) {
     TextButton(
-        modifier = modifier.fillMaxWidth()
-            .height(IntrinsicSize.Min)
-            .heightIn(min = minHeight),
+        modifier = modifier.fillMaxWidth(),
         colors = colors,
         onClick = onClick,
         contentPadding = PaddingValues(),
         shape = RectangleShape,
     ) {
         Box(
-            modifier = Modifier.fillMaxHeight()
-                .align(Alignment.CenterVertically)
+            modifier = Modifier
                 .padding(horizontal = LocalDimensions.current.xxsSpacing)
-                .aspectRatio(1f),
+                .size(minHeight)
+                .align(Alignment.CenterVertically),
             content = icon
         )
 
@@ -306,6 +304,18 @@ fun ItemButton(
 fun PreviewItemButton() {
     PreviewTheme {
         ItemButton(
+            textId = R.string.groupCreate,
+            icon = R.drawable.ic_group,
+            onClick = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+fun PreviewLargeItemButton() {
+    PreviewTheme {
+        LargeItemButton(
             textId = R.string.groupCreate,
             icon = R.drawable.ic_group,
             onClick = {}

--- a/app/src/main/java/org/thoughtcrime/securesms/ui/theme/Dimensions.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/ui/theme/Dimensions.kt
@@ -15,7 +15,6 @@ data class Dimensions(
     val mediumSpacing: Dp = 36.dp,
     val xlargeSpacing: Dp = 64.dp,
 
-    val dividerIndent: Dp = 60.dp,
     val appBarHeight: Dp = 64.dp,
     val minItemButtonHeight: Dp = 50.dp,
     val minLargeItemButtonHeight: Dp = 60.dp,


### PR DESCRIPTION
[SES-1714](https://optf.atlassian.net/browse/SES-1714) and [SES-1715](https://optf.atlassian.net/browse/SES-1715)
Making sure an approved message request sets the contact as visible. They could have been set to hidden if the contact had previously sent another message request which was then declined.
Upon sending another one we need to make sure the contact is set to visible once that request is approved.

Cleaning up our ItemButton to use the height appropriately and making sure the padding is used well for the dividers