### PR TITLE
Fix crashes when removing spaces in mention texts

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/mention/MentionViewModel.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/mention/MentionViewModel.kt
@@ -202,13 +202,17 @@ class MentionViewModel(
         val sb = StringBuilder()
         var offset = 0
         for ((span, range) in spansWithRanges) {
-            // Add content before the mention span
-            sb.append(editable, offset, range.first)
+            // Add content before the mention span. There's a possibility of overlapping spans so we need to
+            // safe guard the start offset here to not go over our span's start.
+            val thisMentionStart = range.first
+            val lastMentionEnd = offset.coerceAtMost(thisMentionStart)
+            sb.append(editable, lastMentionEnd, thisMentionStart)
 
             // Replace the mention span with "@public key"
             sb.append('@').append(span.member.publicKey).append(' ')
 
-            offset = range.last + 1
+            // Safe guard offset to not go over the end of the editable.
+            offset = (range.last + 1).coerceAtMost(editable.length)
         }
 
         // Add the remaining content

--- a/app/src/test/java/org/thoughtcrime/securesms/conversation/v2/MentionViewModelTest.kt
+++ b/app/src/test/java/org/thoughtcrime/securesms/conversation/v2/MentionViewModelTest.kt
@@ -179,6 +179,11 @@ class MentionViewModelTest {
             // Should have normalised message with selected candidate
             assertThat(mentionViewModel.normalizeMessageBody())
                 .isEqualTo("Hi @pubkey1 ")
+
+            // Should have correct normalised message even with the last space deleted
+            editable.delete(editable.length - 1, editable.length)
+            assertThat(mentionViewModel.normalizeMessageBody())
+                .isEqualTo("Hi @pubkey1 ")
         }
     }
 }


### PR DESCRIPTION
Safe guard a few places so exception cases be handled:

1. When deleting the space after a mention, the span will occupy the trailing of the text, which will have a special case of `end offset == string length`. Addition to it is definitely not going to go well.
2. When deleting the space after a mention, then start another mention, it will create a mention span overlap, which will also crash the app. The normalisation will also need to take this into consideration.
