### PR TITLE
Fixing store crash by removing non required spannable

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/dialogs/DownloadDialog.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/dialogs/DownloadDialog.kt
@@ -37,11 +37,7 @@ class DownloadDialog(private val recipient: Recipient) : DialogFragment() {
         val explanation = Phrase.from(context, R.string.attachmentsAutoDownloadModalDescription)
             .put(CONVERSATION_NAME_KEY, recipient.toShortString())
             .format()
-        val spannable = SpannableStringBuilder(explanation)
-
-        val startIndex = explanation.indexOf(name)
-        spannable.setSpan(StyleSpan(Typeface.BOLD), startIndex, startIndex + name.count(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
-        text(spannable)
+        text(explanation)
 
         button(R.string.download, R.string.AccessibilityId_download) { trust() }
         cancelButton { dismiss() }


### PR DESCRIPTION
https://play.google.com/console/u/0/developers/8294769987979883884/app/4974570314892392602/vitals/crashes/63a087746e2cacff39c1a76d3ecc73fa/details?days=28&versionCode=3835&isUserPerceived=true