### PR TITLE
Making sure restored accounts do not display deleted messages

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/dependencies/ConfigFactory.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/dependencies/ConfigFactory.kt
@@ -196,6 +196,18 @@ class ConfigFactory(
         }
     }
 
+    override fun getConfigTimestamp(forConfigObject: ConfigBase, publicKey: String): Long {
+        val variant = when (forConfigObject) {
+            is UserProfile -> SharedConfigMessage.Kind.USER_PROFILE.name
+            is Contacts -> SharedConfigMessage.Kind.CONTACTS.name
+            is ConversationVolatileConfig -> SharedConfigMessage.Kind.CONVO_INFO_VOLATILE.name
+            is UserGroupsConfig -> SharedConfigMessage.Kind.GROUPS.name
+            else -> throw UnsupportedOperationException("Can't support type of ${forConfigObject::class.simpleName} yet")
+        }
+
+        return configDatabase.retrieveConfigLastUpdateTimestamp(variant, publicKey)
+    }
+
     override fun conversationInConfig(
         publicKey: String?,
         groupPublicKey: String?,

--- a/libsession/src/main/java/org/session/libsession/messaging/messages/Message.kt
+++ b/libsession/src/main/java/org/session/libsession/messaging/messages/Message.kt
@@ -33,12 +33,13 @@ abstract class Message {
 
     companion object {
         fun getThreadId(message: Message, openGroupID: String?, storage: StorageProtocol, shouldCreateThread: Boolean): Long? {
-            val senderOrSync = when (message) {
-                is VisibleMessage -> message.syncTarget ?: message.sender!!
-                is ExpirationTimerUpdate -> message.syncTarget ?: message.sender!!
-                else -> message.sender!!
-            }
-            return storage.getThreadIdFor(senderOrSync, message.groupPublicKey, openGroupID, createThread = shouldCreateThread)
+            return storage.getThreadIdFor(message.senderOrSync, message.groupPublicKey, openGroupID, createThread = shouldCreateThread)
+        }
+
+        val Message.senderOrSync get() = when(this)  {
+            is VisibleMessage -> syncTarget ?: sender!!
+            is ExpirationTimerUpdate -> syncTarget ?: sender!!
+            else -> sender!!
         }
     }
 

--- a/libsession/src/main/java/org/session/libsession/utilities/ConfigFactoryProtocol.kt
+++ b/libsession/src/main/java/org/session/libsession/utilities/ConfigFactoryProtocol.kt
@@ -16,6 +16,8 @@ interface ConfigFactoryProtocol {
 
     fun conversationInConfig(publicKey: String?, groupPublicKey: String?, openGroupId: String?, visibleOnly: Boolean): Boolean
     fun canPerformChange(variant: String, publicKey: String, changeTimestampMs: Long): Boolean
+
+    fun getConfigTimestamp(forConfigObject: ConfigBase, publicKey: String): Long
 }
 
 interface ConfigFactoryUpdateListener {


### PR DESCRIPTION
[SES-2804](https://optf.atlassian.net/browse/SES-2804) - Deleted messages coming back when restoring an account.

Making sure an approved message request sets the contact as visible. They could have been set to hidden if the contact had previously sent another message request which was then declined.
Upon sending another one we need to make sure the contact is set to visible once that request is approved.