### PR TITLE
Fix/empty conversations

### DIFF
--- a/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/conversation/v2/ConversationActivityV2.kt
@@ -1123,8 +1123,8 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
         val openGroup = viewModel.openGroup
 
         // Get the correct placeholder text for this type of empty conversation
-        val isNoteToSelf = recipient.isLocalNumber
         val txtCS: CharSequence = when {
+            // note to self
             recipient.isLocalNumber -> getString(R.string.noteToSelfEmpty)
 
             // If this is a community which we cannot write to
@@ -1141,8 +1141,8 @@ class ConversationActivityV2 : PassphraseRequiredActionBarActivity(), InputBarDe
                     .format()
             }
 
-            recipient.isGroupRecipient -> {
-                // If this is a group or community that we CAN send messages to
+            // 10n1 and groups
+            recipient.is1on1 || recipient.isGroupRecipient -> {
                 Phrase.from(applicationContext, R.string.groupNoMessages)
                     .put(GROUP_NAME_KEY, recipient.toShortString())
                     .format()

--- a/app/src/main/java/org/thoughtcrime/securesms/database/MmsDatabase.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/MmsDatabase.kt
@@ -175,7 +175,7 @@ class MmsDatabase(context: Context, databaseHelper: SQLCipherOpenHelper) : Messa
                         )
                         get(context).groupReceiptDatabase()
                             .update(ourAddress, id, status, timestamp)
-                        get(context).threadDatabase().update(threadId, false, true)
+                        get(context).threadDatabase().update(threadId, false)
                         notifyConversationListeners(threadId)
                     }
                 }
@@ -274,7 +274,7 @@ class MmsDatabase(context: Context, databaseHelper: SQLCipherOpenHelper) : Messa
                     " WHERE " + ID + " = ?", arrayOf(id.toString() + "")
         )
         if (threadId.isPresent) {
-            get(context).threadDatabase().update(threadId.get(), false, true)
+            get(context).threadDatabase().update(threadId.get(), false)
         }
     }
 
@@ -646,7 +646,7 @@ class MmsDatabase(context: Context, databaseHelper: SQLCipherOpenHelper) : Messa
         )
         if (!MmsSmsColumns.Types.isExpirationTimerUpdate(mailbox)) {
             if (runThreadUpdate) {
-                get(context).threadDatabase().update(threadId, true, true)
+                get(context).threadDatabase().update(threadId, true)
             }
         }
         notifyConversationListeners(threadId)
@@ -791,7 +791,7 @@ class MmsDatabase(context: Context, databaseHelper: SQLCipherOpenHelper) : Messa
             }
             setHasSent(threadId, true)
             if (runThreadUpdate) {
-                update(threadId, true, true)
+                update(threadId, true)
             }
         }
         return messageId
@@ -930,7 +930,7 @@ class MmsDatabase(context: Context, databaseHelper: SQLCipherOpenHelper) : Messa
         groupReceiptDatabase.deleteRowsForMessage(messageId)
         val database = databaseHelper.writableDatabase
         database!!.delete(TABLE_NAME, ID_WHERE, arrayOf(messageId.toString()))
-        val threadDeleted = get(context).threadDatabase().update(threadId, false, true)
+        val threadDeleted = get(context).threadDatabase().update(threadId, false)
         notifyConversationListeners(threadId)
         notifyStickerListeners()
         notifyStickerPackListeners()
@@ -948,7 +948,7 @@ class MmsDatabase(context: Context, databaseHelper: SQLCipherOpenHelper) : Messa
             argValues
         )
 
-        val threadDeleted = get(context).threadDatabase().update(threadId, false, true)
+        val threadDeleted = get(context).threadDatabase().update(threadId, false)
         notifyConversationListeners(threadId)
         notifyStickerListeners()
         notifyStickerPackListeners()
@@ -1145,7 +1145,7 @@ class MmsDatabase(context: Context, databaseHelper: SQLCipherOpenHelper) : Messa
         }
         val threadDb = get(context).threadDatabase()
         for (threadId in threadIds) {
-            val threadDeleted = threadDb.update(threadId, false, true)
+            val threadDeleted = threadDb.update(threadId, false)
             notifyConversationListeners(threadId)
         }
         notifyStickerListeners()

--- a/app/src/main/java/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -158,7 +158,7 @@ public class SmsDatabase extends MessagingDatabase {
 
     long threadId = getThreadIdForMessage(id);
 
-    DatabaseComponent.get(context).threadDatabase().update(threadId, false, true);
+    DatabaseComponent.get(context).threadDatabase().update(threadId, false);
     notifyConversationListeners(threadId);
   }
 
@@ -261,7 +261,7 @@ public class SmsDatabase extends MessagingDatabase {
 
     long threadId = getThreadIdForMessage(id);
 
-    DatabaseComponent.get(context).threadDatabase().update(threadId, false, true);
+    DatabaseComponent.get(context).threadDatabase().update(threadId, false);
     notifyConversationListeners(threadId);
   }
 
@@ -346,7 +346,7 @@ public class SmsDatabase extends MessagingDatabase {
                              ID + " = ?",
                              new String[] {String.valueOf(cursor.getLong(cursor.getColumnIndexOrThrow(ID)))});
 
-            DatabaseComponent.get(context).threadDatabase().update(threadId, false, true);
+            DatabaseComponent.get(context).threadDatabase().update(threadId, false);
             notifyConversationListeners(threadId);
             foundMessage = true;
           }
@@ -429,7 +429,7 @@ public class SmsDatabase extends MessagingDatabase {
 
     long threadId = getThreadIdForMessage(messageId);
 
-    DatabaseComponent.get(context).threadDatabase().update(threadId, true, true);
+    DatabaseComponent.get(context).threadDatabase().update(threadId, true);
     notifyConversationListeners(threadId);
     notifyConversationListListeners();
 
@@ -504,7 +504,7 @@ public class SmsDatabase extends MessagingDatabase {
       long           messageId = db.insert(TABLE_NAME, null, values);
 
       if (runThreadUpdate) {
-        DatabaseComponent.get(context).threadDatabase().update(threadId, true, true);
+        DatabaseComponent.get(context).threadDatabase().update(threadId, true);
       }
 
       if (message.getSubscriptionId() != -1) {
@@ -596,7 +596,7 @@ public class SmsDatabase extends MessagingDatabase {
     }
 
     if (runThreadUpdate) {
-      DatabaseComponent.get(context).threadDatabase().update(threadId, true, true);
+      DatabaseComponent.get(context).threadDatabase().update(threadId, true);
     }
     long lastSeen = DatabaseComponent.get(context).threadDatabase().getLastSeenAndHasSent(threadId).first();
     if (lastSeen < message.getSentTimestampMillis()) {
@@ -656,7 +656,7 @@ public class SmsDatabase extends MessagingDatabase {
     long threadId = getThreadIdForMessage(messageId);
     db.delete(TABLE_NAME, ID_WHERE, new String[] {messageId+""});
     notifyConversationListeners(threadId);
-    boolean threadDeleted = DatabaseComponent.get(context).threadDatabase().update(threadId, false, false);
+    boolean threadDeleted = DatabaseComponent.get(context).threadDatabase().update(threadId, false);
     return threadDeleted;
   }
 
@@ -676,7 +676,7 @@ public class SmsDatabase extends MessagingDatabase {
       ID + " IN (" + StringUtils.join(argsArray, ',') + ")",
       argValues
     );
-    boolean threadDeleted = DatabaseComponent.get(context).threadDatabase().update(threadId, false, true);
+    boolean threadDeleted = DatabaseComponent.get(context).threadDatabase().update(threadId, false);
     notifyConversationListeners(threadId);
     return threadDeleted;
   }

--- a/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/Storage.kt
@@ -287,7 +287,7 @@ open class Storage(
 
     override fun updateThread(threadId: Long, unarchive: Boolean) {
         val threadDb = DatabaseComponent.get(context).threadDatabase()
-        threadDb.update(threadId, unarchive, false)
+        threadDb.update(threadId, unarchive)
     }
 
     override fun persist(message: VisibleMessage,

--- a/app/src/main/java/org/thoughtcrime/securesms/database/model/ThreadRecord.java
+++ b/app/src/main/java/org/thoughtcrime/securesms/database/model/ThreadRecord.java
@@ -102,7 +102,11 @@ public class ThreadRecord extends DisplayRecord {
 
     @Override
     public CharSequence getDisplayBody(@NonNull Context context) {
-        if (isGroupUpdateMessage()) {
+        // no need to display anything if there are no messages
+        if(lastMessage == null){
+            return "";
+        }
+        else if (isGroupUpdateMessage()) {
             return context.getString(R.string.groupUpdated);
         } else if (isOpenGroupInvitation()) {
             return context.getString(R.string.communityInvitation);

--- a/app/src/main/res/layout/activity_conversation_v2.xml
+++ b/app/src/main/res/layout/activity_conversation_v2.xml
@@ -271,14 +271,14 @@
 
     <TextView
         android:padding="@dimen/medium_spacing"
-        android:textSize="@dimen/small_font_size"
-        android:textColor="?android:textColorSecondary"
+        style="@style/Signal.Text.Preview"
+        android:textColor="?android:textColorTertiary"
         android:textAlignment="center"
         android:id="@+id/placeholderText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/large_spacing"
         app:layout_constraintTop_toBottomOf="@+id/outdatedBanner"
-        android:elevation="8dp"
         android:contentDescription="@string/AccessibilityId_control_message"
         tools:text="Some Control Message Text"
         />


### PR DESCRIPTION
Taking care of various tickets that have to do with empty conversations disappearing when empty or when messages have been deleted in them.
Added proper empty states for each conversation type.
[SES-1723](https://optf.atlassian.net/browse/SES-1723)
[SES-2809](https://optf.atlassian.net/browse/SES-2809)
[SES-2814](https://optf.atlassian.net/browse/SES-2814)